### PR TITLE
Transaction builder

### DIFF
--- a/readme_bridge.md
+++ b/readme_bridge.md
@@ -71,6 +71,112 @@ Then you can start the server:
 
 `Content-Type` of requests data should be `application/x-www-form-urlencoded`.
 
+### POST /builder
+
+Builds a transaction from a given request. `Content-Type` of this request should be `application/json`. Check [List of operations](https://www.stellar.org/developers/learn/concepts/list-of-operations.html) doc to learn more about how each operation looks like.
+
+#### Request
+
+Check example request below (remove comments before submitting it to the `bridge` server):
+
+```json
+{
+  // Transaction source account
+  "source": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+  // Sequence number
+  "sequence_number": "123",
+  // List of operations in this transaction
+  "operations": [
+    // First operation
+    {
+      // Operation type
+      "type": "create_account",
+      // Operation body
+      "body": {
+        // Don't send source field if operation source account is equal to transaction source account
+        "source": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "destination": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "starting_balance": "50"
+      }
+    },
+    // Second operation
+    {
+      "type": "payment",
+      "body": {
+        "source": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "destination": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "amount": "1050",
+        "asset": {
+          "code": "USD",
+          "issuer": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT"
+        }
+      }
+    },
+    {
+      "type": "path_payment",
+      "body": {
+        "source": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "destination": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "destination_amount": "10",
+        "send_max": "1050",
+        "send_asset": {
+          "code": "USD",
+          "issuer": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT"
+        },
+        "destination_asset": {
+          "code": "EUR",
+          "issuer": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT"
+        },
+        "path": [
+	        {}, // Native asset
+      		{
+              "code": "ZAR",
+              "issuer": "GBNIVKJTD2SMAXB5ALPBZ7CHRYYLCO5XSH55H6TI3Z37P7SCRXQVESG2"
+            }
+        ]
+      }
+    },
+    {
+      "type": "change_trust",
+      "body": {
+        "source": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "asset": {
+          "code": "USD",
+          "issuer": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT"
+        }
+      }
+    },
+    {
+      "type": "allow_trust",
+      "body": {
+        "source": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "trustor": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
+        "asset_code": "USD",
+        "authorize": true
+      }
+    }
+  ],
+  // Array of signers
+  "signers": ["SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"]
+}
+```
+
+Assets are represented by a JSON object with two fields: `code` and `issuer`. Empty JSON object represents [native asset](https://www.stellar.org/developers/learn/concepts/assets.html#lumens-xlm-).
+
+#### Response
+
+When transaction can be successfully built it will return a JSON object with a single `transaction_envelope` field that will contain base64-encoded `TransactionEnvelope` XDR object:
+
+```json
+{
+    "transaction_envelope": "AAAAAEYnZH8R8a8qXgBJl6EgZLRvmfvEpp8NEUQ9i..."
+}
+```
+
+In case of error it will return one of the following errors:
+* [`InternalServerError`](./blob/master/src/github.com/stellar/gateway/protocols/errors.go)
+* [`InvalidParameterError`](./blob/master/src/github.com/stellar/gateway/protocols/errors.go)
+
 ### POST /payment
 
 Builds and submits a transaction with a single [`payment`](https://www.stellar.org/developers/learn/concepts/list-of-operations.html#payment), [`path_payment`](https://www.stellar.org/developers/learn/concepts/list-of-operations.html#path-payment) or [`create_account`](https://www.stellar.org/developers/learn/concepts/list-of-operations.html#create-account) (when sending native asset to account that does not exist) operation built from following parameters.

--- a/readme_bridge.md
+++ b/readme_bridge.md
@@ -128,13 +128,61 @@ Check example request below (remove comments before submitting it to the `bridge
           "issuer": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT"
         },
         "path": [
-	        {}, // Native asset
-      		{
+          {}, // Native asset
+          {
               "code": "ZAR",
               "issuer": "GBNIVKJTD2SMAXB5ALPBZ7CHRYYLCO5XSH55H6TI3Z37P7SCRXQVESG2"
             }
         ]
       }
+    },
+    {
+        "type": "manage_offer",
+        "body": {
+          "selling": {
+            "code": "EUR",
+            "issuer": "GDOJMKTDLGGLROSSM5BV5MXIAQ3JZHASQFUV55WBJ45AFOUXSVVFGPTJ"
+          },
+          "buying": {
+            "code": "USD",
+            "issuer": "GACETOPHMOLSZLG5IQ3D6KQDKCAAYUYTTQHIEY6IGZE4VOBDD2YY6YAO"
+          },
+          "amount": "123456",
+          "price": "2.93850088",
+          "offer_id": "100"
+        }
+    },
+    {
+        "type": "create_passive_offer",
+        "body": {
+          "selling": {
+            "code": "EUR",
+            "issuer": "GDOJMKTDLGGLROSSM5BV5MXIAQ3JZHASQFUV55WBJ45AFOUXSVVFGPTJ"
+          },
+          "buying": {
+            "code": "USD",
+            "issuer": "GACETOPHMOLSZLG5IQ3D6KQDKCAAYUYTTQHIEY6IGZE4VOBDD2YY6YAO"
+          },
+          "amount": "123456",
+          "price": "2.93850088"
+        }
+    },
+    {
+        "type": "set_options",
+        "body": {
+          "inflation_dest": "GBMPZVOMJ67WQBTBCVURDKTGL4557272EGQMAJCXPSMLOE63XPLL6SVA",
+          "set_flags": [1, 2],
+          "clear_flags": [4],
+          "master_weight": 100,
+          "low_threshold": 1,
+          "medium_threshold": 2,
+          "high_threshold": 3,
+          "home_domain": "stellar.org",
+          "signer": {
+            "public_key": "GA6VMJJQM2QBPPIXK2UVTAOS4XSSSAKSCOGFQE55IMRBQR65GIVDTTQV",
+            "weight": 5
+          }
+        }
     },
     {
       "type": "change_trust",
@@ -154,6 +202,23 @@ Check example request below (remove comments before submitting it to the `bridge
         "asset_code": "USD",
         "authorize": true
       }
+    },
+    {
+        "type": "account_merge",
+        "body": {
+          "destination": "GBLH67TQHRNRLERQEIQJDNBV2DSWPHAPP43MBIF7DVKA7X55APUNS4LL"
+        }
+    },
+    {
+        "type": "inflation",
+        "body": {}
+    },
+    {
+        "type": "manage_data",
+        "body": {
+          "name": "test_data",
+          "data": "AQIDBAUG"
+        }
     }
   ],
   // Array of signers

--- a/src/github.com/stellar/gateway/bridge/app.go
+++ b/src/github.com/stellar/gateway/bridge/app.go
@@ -181,6 +181,7 @@ func (a *App) Serve() {
 		log.Warning("accounts.authorizing_seed not provided. /authorize endpoint will not be available.")
 	}
 
+	goji.Post("/builder", a.requestHandler.Builder)
 	goji.Post("/payment", a.requestHandler.Payment)
 
 	goji.Serve()

--- a/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder.go
+++ b/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder.go
@@ -20,42 +20,24 @@ func (rh *RequestHandler) Builder(w http.ResponseWriter, r *http.Request) {
 	err := decoder.Decode(&request)
 	if err != nil {
 		log.WithFields(log.Fields{"err": err}).Error("Error decoding request")
-		server.Write(w, protocols.InternalServerError)
+		server.Write(w, protocols.InvalidParameterError)
 		return
 	}
 
-	// err = request.Validate()
-	// if err != nil {
-	// 	errorResponse := err.(*protocols.ErrorResponse)
-	// 	log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
-	// 	server.Write(w, errorResponse)
-	// 	return
-	// }
+	err = request.Process()
+	if err != nil {
+		errorResponse := err.(*protocols.ErrorResponse)
+		log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
+		server.Write(w, errorResponse)
+		return
+	}
 
-	var operationsData []bridge.OperationData
-	for i, operation := range request.Operations {
-		switch operation.Type {
-		case bridge.OperationTypeCreateAccount:
-			var createAccount bridge.CreateAccountOperationData
-			err = json.Unmarshal(operation.Data, &createAccount)
-			operationsData = append(operationsData, createAccount)
-		case bridge.OperationTypePayment:
-			var payment bridge.PaymentOperationData
-			err = json.Unmarshal(operation.Data, &payment)
-			operationsData = append(operationsData, payment)
-		default:
-			errorResponse := protocols.NewInvalidParameterError("operations["+strconv.Itoa(i)+"][type]", string(operation.Type))
-			log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
-			server.Write(w, errorResponse)
-			return
-		}
-
-		if err != nil {
-			errorResponse := protocols.NewInvalidParameterError("operations["+strconv.Itoa(i)+"][data]", "")
-			log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
-			server.Write(w, errorResponse)
-			return
-		}
+	err = request.Validate()
+	if err != nil {
+		errorResponse := err.(*protocols.ErrorResponse)
+		log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
+		server.Write(w, errorResponse)
+		return
 	}
 
 	sequenceNumber, err := strconv.ParseUint(request.SequenceNumber, 10, 64)
@@ -69,19 +51,25 @@ func (rh *RequestHandler) Builder(w http.ResponseWriter, r *http.Request) {
 	mutators := []b.TransactionMutator{
 		b.SourceAccount{request.Source},
 		b.Sequence{sequenceNumber},
-		b.Network{"TODO change"},
+		b.Network{rh.Config.NetworkPassphrase},
 	}
 
-	for _, operationData := range operationsData {
-		mutators = append(mutators, operationData.ToTransactionMutator())
+	for _, operation := range request.Operations {
+		mutators = append(mutators, operation.Body.ToTransactionMutator())
 	}
 
 	tx := b.Transaction(mutators...)
-	// TODO check tx.Err
+
+	if tx.Err != nil {
+		log.WithFields(log.Fields{"err": err, "request": request}).Error("TransactionBuilder returned error")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
 	txe := tx.Sign(request.Signers...)
 	txeB64, err := txe.Base64()
 	if err != nil {
-		log.WithFields(log.Fields{"err": err}).Error("Error encoding transaction envelope")
+		log.WithFields(log.Fields{"err": err, "request": request}).Error("Error encoding transaction envelope")
 		server.Write(w, protocols.InternalServerError)
 		return
 	}

--- a/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder.go
+++ b/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"encoding/json"
+	log "github.com/Sirupsen/logrus"
+	"net/http"
+	"strconv"
+
+	"github.com/stellar/gateway/protocols"
+	"github.com/stellar/gateway/protocols/bridge"
+	"github.com/stellar/gateway/server"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// Builder implements /builder endpoint
+func (rh *RequestHandler) Builder(w http.ResponseWriter, r *http.Request) {
+	var request bridge.BuilderRequest
+
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&request)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error decoding request")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
+	// err = request.Validate()
+	// if err != nil {
+	// 	errorResponse := err.(*protocols.ErrorResponse)
+	// 	log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
+	// 	server.Write(w, errorResponse)
+	// 	return
+	// }
+
+	var operationsData []bridge.OperationData
+	for i, operation := range request.Operations {
+		switch operation.Type {
+		case bridge.OperationTypeCreateAccount:
+			var createAccount bridge.CreateAccountOperationData
+			err = json.Unmarshal(operation.Data, &createAccount)
+			operationsData = append(operationsData, createAccount)
+		case bridge.OperationTypePayment:
+			var payment bridge.PaymentOperationData
+			err = json.Unmarshal(operation.Data, &payment)
+			operationsData = append(operationsData, payment)
+		default:
+			errorResponse := protocols.NewInvalidParameterError("operations["+strconv.Itoa(i)+"][type]", string(operation.Type))
+			log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
+			server.Write(w, errorResponse)
+			return
+		}
+
+		if err != nil {
+			errorResponse := protocols.NewInvalidParameterError("operations["+strconv.Itoa(i)+"][data]", "")
+			log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
+			server.Write(w, errorResponse)
+			return
+		}
+	}
+
+	sequenceNumber, err := strconv.ParseUint(request.SequenceNumber, 10, 64)
+	if err != nil {
+		errorResponse := protocols.NewInvalidParameterError("sequence_number", request.SequenceNumber)
+		log.WithFields(errorResponse.LogData).Error(errorResponse.Error())
+		server.Write(w, errorResponse)
+		return
+	}
+
+	mutators := []b.TransactionMutator{
+		b.SourceAccount{request.Source},
+		b.Sequence{sequenceNumber},
+		b.Network{"TODO change"},
+	}
+
+	for _, operationData := range operationsData {
+		mutators = append(mutators, operationData.ToTransactionMutator())
+	}
+
+	tx := b.Transaction(mutators...)
+	// TODO check tx.Err
+	txe := tx.Sign(request.Signers...)
+	txeB64, err := txe.Base64()
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error encoding transaction envelope")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
+	server.Write(w, &bridge.BuilderResponse{TransactionEnvelope: txeB64})
+}

--- a/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder_test.go
+++ b/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder_test.go
@@ -1,0 +1,398 @@
+package handlers
+
+import (
+	// "encoding/hex"
+	// "errors"
+	"net/http"
+	"net/http/httptest"
+	// "net/url"
+	"strings"
+	"testing"
+
+	"github.com/facebookgo/inject"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/gateway/bridge/config"
+	"github.com/stellar/gateway/mocks"
+	"github.com/stellar/gateway/net"
+	"github.com/stellar/gateway/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestHandlerBuilder(t *testing.T) {
+	c := &config.Config{NetworkPassphrase: "Test SDF Network ; September 2015"}
+	mockHorizon := new(mocks.MockHorizon)
+	mockHTTPClient := new(mocks.MockHTTPClient)
+	mockTransactionSubmitter := new(mocks.MockTransactionSubmitter)
+	mockFederationResolver := new(mocks.MockFederationResolver)
+	mockStellartomlResolver := new(mocks.MockStellartomlResolver)
+	requestHandler := RequestHandler{}
+
+	// Inject mocks
+	var g inject.Graph
+
+	err := g.Provide(
+		&inject.Object{Value: &requestHandler},
+		&inject.Object{Value: c},
+		&inject.Object{Value: mockHorizon},
+		&inject.Object{Value: mockHTTPClient},
+		&inject.Object{Value: mockTransactionSubmitter},
+		&inject.Object{Value: mockFederationResolver},
+		&inject.Object{Value: mockStellartomlResolver},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := g.Populate(); err != nil {
+		panic(err)
+	}
+
+	testServer := httptest.NewServer(http.HandlerFunc(requestHandler.Builder))
+	defer testServer.Close()
+
+	Convey("Builder", t, func() {
+		Convey("CreateAccount", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "create_account",
+        "body": {
+        	"destination": "GCOEGO43PFSLE4K7WRZQNRO3PIOTRLKRASP32W7DSPBF65XFT4V6PSV3",
+        	"starting_balance": "50"
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAnEM7m3lksnFftHMGxdt6HTitUQSfvVvjk8JfduWfK+cAAAAAHc1lAAAAAAAAAAABn420/AAAAECXY+neSolhAeHUXf+UrOV6PjeJnvLM/HqjOlOEWD3hmu/z9aBksDu9zqa26jS14eMpZzq8sofnnvt248FUO+cP"
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("Payment", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "payment",
+        "body": {
+        	"destination": "GCOEGO43PFSLE4K7WRZQNRO3PIOTRLKRASP32W7DSPBF65XFT4V6PSV3",
+        	"amount": "100",
+        	"asset": {
+        		"code": "USD",
+        		"issuer": "GACETOPHMOLSZLG5IQ3D6KQDKCAAYUYTTQHIEY6IGZE4VOBDD2YY6YAO"
+        	}
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAnEM7m3lksnFftHMGxdt6HTitUQSfvVvjk8JfduWfK+cAAAABVVNEAAAAAAAESbnnY5csrN1ENj8qA1CADFMTnA6CY8g2Scq4Ix6xjwAAAAA7msoAAAAAAAAAAAGfjbT8AAAAQGlQbmCv74lzQpjUOn8dsQ9/BFCKHSev6DLo4lS2wcS20GpfIjGZSXIAry/3porFM+3xrvBWlIH9Tr/QFKjqRAU="
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("PathPayment", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "path_payment",
+        "body": {
+        	"source": "GBYLUAJBHGZMVAYCALM4ZRTAOY74NTSSULG42VKVY2EOWS5X2HFBB2VL",
+        	"destination": "GCOEGO43PFSLE4K7WRZQNRO3PIOTRLKRASP32W7DSPBF65XFT4V6PSV3",
+        	"destination_amount": "500",
+        	"destination_asset": {
+        		"code": "EUR",
+        		"issuer": "GDOJMKTDLGGLROSSM5BV5MXIAQ3JZHASQFUV55WBJ45AFOUXSVVFGPTJ"
+        	},
+        	"send_max": "100",
+        	"send_asset": {
+        		"code": "USD",
+        		"issuer": "GACETOPHMOLSZLG5IQ3D6KQDKCAAYUYTTQHIEY6IGZE4VOBDD2YY6YAO"
+        	},
+        	"path": [
+        		{
+	        		"code": "ABCDEFG",
+	        		"issuer": "GD4RIHH2HWB4MPJN72G2VGLRPUXDODFNQG6DVU47HMSSSF3RIQ4UXALD"
+	        	},
+	        	{}
+        	]
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAQAAAABwugEhObLKgwIC2czGYHY/xs5Sos3NVVXGiOtLt9HKEAAAAAIAAAABVVNEAAAAAAAESbnnY5csrN1ENj8qA1CADFMTnA6CY8g2Scq4Ix6xjwAAAAA7msoAAAAAAJxDO5t5ZLJxX7RzBsXbeh04rVEEn71b45PCX3blnyvnAAAAAUVVUgAAAAAA3JYqY1mMuLpSZ0NesugENpycEoFpXvbBTzoCupeValMAAAABKgXyAAAAAAIAAAACQUJDREVGRwAAAAAAAAAAAPkUHPo9g8Y9Lf6NqplxfS43DK2BvDrTnzslKRdxRDlLAAAAAAAAAAAAAAABn420/AAAAEA9DEvKZhLwLcStP8/ZsqaEAdlNc91Eyz5mLUiN19etsIYaTPNugsVEWYJOiulXXSIwwitoyxQ1t2jr6VS0mXcB"
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("ManageOffer", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "manage_offer",
+        "body": {
+        	"selling": {
+        		"code": "EUR",
+        		"issuer": "GDOJMKTDLGGLROSSM5BV5MXIAQ3JZHASQFUV55WBJ45AFOUXSVVFGPTJ"
+        	},
+        	"buying": {
+        		"code": "USD",
+        		"issuer": "GACETOPHMOLSZLG5IQ3D6KQDKCAAYUYTTQHIEY6IGZE4VOBDD2YY6YAO"
+        	},
+        	"amount": "123456",
+        	"price": "2.93850088",
+        	"offer_id": "100"
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAMAAAABRVVSAAAAAADclipjWYy4ulJnQ16y6AQ2nJwSgWle9sFPOgK6l5VqUwAAAAFVU0QAAAAAAARJuedjlyys3UQ2PyoDUIAMUxOcDoJjyDZJyrgjHrGPAAABH3GCoAACMHl9AL68IAAAAAAAAABkAAAAAAAAAAGfjbT8AAAAQEpMML2mghfM2Dzkpw6eT1N00rrIC7v3xe8zy7yc8rcGzFxIw/4/E69uq+rst+xDoeMTn0b3iBtjr2DEV52o/wE="
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("CreatePassiveOffer", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "create_passive_offer",
+        "body": {
+        	"selling": {
+        		"code": "EUR",
+        		"issuer": "GDOJMKTDLGGLROSSM5BV5MXIAQ3JZHASQFUV55WBJ45AFOUXSVVFGPTJ"
+        	},
+        	"buying": {
+        		"code": "USD",
+        		"issuer": "GACETOPHMOLSZLG5IQ3D6KQDKCAAYUYTTQHIEY6IGZE4VOBDD2YY6YAO"
+        	},
+        	"amount": "123456",
+        	"price": "2.93850088"
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAQAAAABRVVSAAAAAADclipjWYy4ulJnQ16y6AQ2nJwSgWle9sFPOgK6l5VqUwAAAAFVU0QAAAAAAARJuedjlyys3UQ2PyoDUIAMUxOcDoJjyDZJyrgjHrGPAAABH3GCoAACMHl9AL68IAAAAAAAAAABn420/AAAAEAtK8juIThYp4LXtgpN8gVNRR42iiR6tz8euSKqqqzKGELCHcPrmFUuYqtecrJi8CyPCYTp0nqGY9mtJCHFYpsC"
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("SetOptions", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "set_options",
+        "body": {
+        	"inflation_dest": "GBMPZVOMJ67WQBTBCVURDKTGL4557272EGQMAJCXPSMLOE63XPLL6SVA",
+        	"set_flags": [1, 2],
+        	"clear_flags": [4],
+        	"master_weight": 100,
+        	"low_threshold": 1,
+        	"medium_threshold": 2,
+        	"high_threshold": 3,
+        	"home_domain": "stellar.org",
+        	"signer": {
+        		"public_key": "GA6VMJJQM2QBPPIXK2UVTAOS4XSSSAKSCOGFQE55IMRBQR65GIVDTTQV",
+        		"weight": 5
+        	}
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAUAAAABAAAAAFj81cxPv2gGYRVpEapmXzvf6/ohoMAkV3yYtxPbu9a/AAAAAQAAAAQAAAABAAAAAwAAAAEAAABkAAAAAQAAAAEAAAABAAAAAgAAAAEAAAADAAAAAQAAAAtzdGVsbGFyLm9yZwAAAAABAAAAAD1WJTBmoBe9F1apWYHS5eUpAVITjFgTvUMiGEfdMio5AAAABQAAAAAAAAABn420/AAAAEAtQAlVOLBR6sb/YHRg7XcSEPSJ07irs6cCSDpK95rYE7Ga5ghiLXHqRJQ2B9cMmf8FYqzeaHdYPiESZqowhb0F"
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("ChangeTrust", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "change_trust",
+        "body": {
+        	"asset": {
+        		"code": "USD",
+        		"issuer": "GCHGRVNTXAV3OXNMCSA63BUCD6AZZX6PN2542QB6GIVTXGHQ65XS35DS"
+        	}
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAACOaNWzuCu3XawUge2Ggh+BnN/PbrvNQD4yKzuY8PdvLX//////////AAAAAAAAAAGfjbT8AAAAQFftcSiqTvZOQwDJnoJ7buLgYXyjRacggCZ7yEhnPN4eXxlpQycvLLFa3U8xv0Mcnx5frSNKxu0sDIOm88Iicw8="
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("AllowTrust", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "allow_trust",
+        "body": {
+        	"asset_code": "USDUSD",
+        	"trustor": "GBLH67TQHRNRLERQEIQJDNBV2DSWPHAPP43MBIF7DVKA7X55APUNS4LL",
+        	"authorize": true
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAcAAAAAVn9+cDxbFZIwIiCRtDXQ5WecD382wKC/HVQP370D6NkAAAACVVNEVVNEAAAAAAAAAAAAAQAAAAAAAAABn420/AAAAEA9Ht9mJaKdYoRg/rAX/cl/Q89Juhmi8f7iGBdCrSVAs+VN7NVJXR+0aZpoZIjcJD/QBPiuzZIK1ea2fN7I0I8J"
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("AccountMerge", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "account_merge",
+        "body": {
+        	"destination": "GBLH67TQHRNRLERQEIQJDNBV2DSWPHAPP43MBIF7DVKA7X55APUNS4LL"
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAgAAAAAVn9+cDxbFZIwIiCRtDXQ5WecD382wKC/HVQP370D6NkAAAAAAAAAAZ+NtPwAAABALCyRn/E/CgLdPWGgP+1pd2Lkf3jWgNANKQ4QeGgUxgROhqkTUXaPA6XzOWS8yUpzZMufl6nkh8UFqa6Hc1emCA=="
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("Inflation", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "inflation",
+        "body": {}
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAkAAAAAAAAAAZ+NtPwAAABAlBFCwJ3VzBd+CE+n3mA4t71SVrDIjSgRyBnz9zYLN7qkqu8AD6cyvMRj8/alSozSPAZcSe+qBEO7E5biR+YrAA=="
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+
+		Convey("ManageData", func() {
+			data := test.StringToJSONMap(`{
+  "source": "GBWJES3WOKK7PRLJKZVGIPVFGQSSGCRMY7H3GCZ7BEG6ZTDB4FZXTPJ5",
+  "sequence_number": "123",
+  "operations": [
+    {
+        "type": "manage_data",
+        "body": {
+        	"name": "test_data",
+        	"data": "AQIDBAUG"
+        }
+    }
+  ],
+  "signers": ["SABY7FRMMJWPBTKQQ2ZN43AUJQ3Z2ZAK36VYSG2SPE2ABNQXA66H5E5G"]
+}`)
+
+			Convey("it should return correct XDR", func() {
+				statusCode, response := net.JSONGetResponse(testServer, data)
+				responseString := strings.TrimSpace(string(response))
+				assert.Equal(t, 200, statusCode)
+				expected := test.StringToJSONMap(`{
+  "transaction_envelope": "AAAAAGySS3ZylffFaVZqZD6lNCUjCizHz7MLPwkN7Mxh4XN5AAAAZAAAAAAAAAB7AAAAAAAAAAAAAAABAAAAAAAAAAoAAAAJdGVzdF9kYXRhAAAAAAAAAQAAAAYBAgMEBQYAAAAAAAAAAAABn420/AAAAEBkO27ebDbsn1WzzLH5lUfJH3Y0Pgd1dlRx3Ip1dEZkvRPFFDLZuXi5DlW9uxNgeqThNsqnK7PPHfhyuWBVQpgN"
+}`)
+				assert.Equal(t, expected, test.StringToJSONMap(responseString))
+			})
+		})
+	})
+}

--- a/src/github.com/stellar/gateway/net/main.go
+++ b/src/github.com/stellar/gateway/net/main.go
@@ -2,6 +2,7 @@ package net
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -27,6 +28,29 @@ func GetResponse(testServer *httptest.Server, values url.Values) (int, []byte) {
 	if err != nil {
 		panic(err)
 	}
+	response, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	return res.StatusCode, response
+}
+
+// JSONGetResponse is used in tests
+func JSONGetResponse(testServer *httptest.Server, data map[string]interface{}) (int, []byte) {
+	j, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	req, err := http.NewRequest("POST", testServer.URL, bytes.NewBuffer(j))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+
 	response, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {

--- a/src/github.com/stellar/gateway/protocols/bridge/builder.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder.go
@@ -63,6 +63,14 @@ func (r BuilderRequest) Process() error {
 			var pathPayment PathPaymentOperationBody
 			err = json.Unmarshal(operation.RawBody, &pathPayment)
 			operationBody = pathPayment
+		case OperationTypeManageOffer:
+			var manageOffer ManageOfferOperationBody
+			err = json.Unmarshal(operation.RawBody, &manageOffer)
+			operationBody = manageOffer
+		case OperationTypeSetOptions:
+			var setOptions SetOptionsOperationBody
+			err = json.Unmarshal(operation.RawBody, &setOptions)
+			operationBody = setOptions
 		case OperationTypeChangeTrust:
 			var changeTrust ChangeTrustOperationBody
 			err = json.Unmarshal(operation.RawBody, &changeTrust)
@@ -71,6 +79,14 @@ func (r BuilderRequest) Process() error {
 			var allowTrust AllowTrustOperationBody
 			err = json.Unmarshal(operation.RawBody, &allowTrust)
 			operationBody = allowTrust
+		case OperationTypeAccountMerge:
+			var accountMerge AccountMergeOperationBody
+			err = json.Unmarshal(operation.RawBody, &accountMerge)
+			operationBody = accountMerge
+		case OperationTypeInflation:
+			var inflation InflationOperationBody
+			err = json.Unmarshal(operation.RawBody, &inflation)
+			operationBody = inflation
 		default:
 			return protocols.NewInvalidParameterError("operations["+strconv.Itoa(i)+"][type]", string(operation.Type))
 		}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder.go
@@ -87,6 +87,10 @@ func (r BuilderRequest) Process() error {
 
 // Validate validates if the request is correct.
 func (r BuilderRequest) Validate() error {
+	if !protocols.IsValidAccountID(r.Source) {
+		return protocols.NewInvalidParameterError("source", r.Source)
+	}
+
 	for _, operation := range r.Operations {
 		err := operation.Body.Validate()
 		if err != nil {

--- a/src/github.com/stellar/gateway/protocols/bridge/builder.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder.go
@@ -1,0 +1,122 @@
+package bridge
+
+import (
+	"encoding/json"
+
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// OperationType is the type of operation
+type OperationType string
+
+const (
+	// OperationTypeCreateAccount represents create_account operation
+	OperationTypeCreateAccount OperationType = "create_account"
+	// OperationTypePayment represents payment operation
+	OperationTypePayment OperationType = "payment"
+	// OperationTypePathPayment represents path_payment operation
+	OperationTypePathPayment OperationType = "path_payment"
+	// OperationTypeManageOffer represents manage_offer operation
+	OperationTypeManageOffer OperationType = "manage_offer"
+	// OperationTypeCreatePassiveOffer represents create_passive_offer operation
+	OperationTypeCreatePassiveOffer OperationType = "create_passive_offer"
+	// OperationTypeSetOptions represents set_options operation
+	OperationTypeSetOptions OperationType = "set_options"
+	// OperationTypeChangeTrust represents change_trust operation
+	OperationTypeChangeTrust OperationType = "change_trust"
+	// OperationTypeAllowTrust represents allow_trust operation
+	OperationTypeAllowTrust OperationType = "allow_trust"
+	// OperationTypeAccountMerge represents account_merge operation
+	OperationTypeAccountMerge OperationType = "account_merge"
+	// OperationTypeInflation represents inflation operation
+	OperationTypeInflation OperationType = "inflation"
+	// OperationTypeManageData represents manage_data operation
+	OperationTypeManageData OperationType = "manage_data"
+)
+
+// BuilderRequest represents request made to /builder endpoint of bridge server
+type BuilderRequest struct {
+	Source         string
+	SequenceNumber string `json:"sequence_number"`
+	Operations     []Operation
+	Signers        []string
+}
+
+// Operation contains
+type Operation struct {
+	Type OperationType
+	Data json.RawMessage // delay parsing until we know operation type
+}
+
+// OperationData interface is a common interface for builder operations
+type OperationData interface {
+	ToTransactionMutator() b.TransactionMutator
+}
+
+// CreateAccountOperationData represents create_account operation
+type CreateAccountOperationData struct {
+	Source          *string
+	Destination     string
+	StartingBalance string `json:"starting_balance"`
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op CreateAccountOperationData) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{
+		b.Destination{op.Destination},
+		b.NativeAmount{op.StartingBalance},
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.CreateAccount(mutators...)
+}
+
+// PaymentOperationData represents payment operation
+type PaymentOperationData struct {
+	Source      *string
+	Destination string
+	Amount      string
+	AssetCode   *string `json:"asset_code"`
+	AssetIssuer *string `json:"asset_issuer"`
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op PaymentOperationData) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{
+		b.Destination{op.Destination},
+	}
+
+	if op.AssetCode != nil && op.AssetIssuer != nil {
+		mutators = append(
+			mutators,
+			b.CreditAmount{*op.AssetCode, *op.AssetIssuer, op.Amount},
+		)
+	} else {
+		mutators = append(
+			mutators,
+			b.NativeAmount{op.Amount},
+		)
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.Payment(mutators...)
+}
+
+// BuilderResponse represents response returned by /builder endpoint of bridge server
+type BuilderResponse struct {
+	protocols.SuccessResponse
+	TransactionEnvelope string `json:"transaction_envelope"`
+}
+
+// Marshal marshals BuilderResponse
+func (response *BuilderResponse) Marshal() []byte {
+	json, _ := json.MarshalIndent(response, "", "  ")
+	return json
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_account_merge.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_account_merge.go
@@ -1,0 +1,36 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// AccountMergeOperationBody represents account_merge operation
+type AccountMergeOperationBody struct {
+	Source      *string
+	Destination string
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op AccountMergeOperationBody) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{b.Destination{op.Destination}}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.AccountMerge(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op AccountMergeOperationBody) Validate() error {
+	if !protocols.IsValidAccountID(op.Destination) {
+		return protocols.NewInvalidParameterError("destination", op.Destination)
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_allow_trust.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_allow_trust.go
@@ -1,0 +1,46 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// AllowTrustOperationBody represents create_account operation
+type AllowTrustOperationBody struct {
+	Source    *string
+	AssetCode string `json:"asset_code"`
+	Trustor   string
+	Authorize bool
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op AllowTrustOperationBody) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{
+		b.AllowTrustAsset{op.AssetCode},
+		b.Trustor{op.Trustor},
+		b.Authorize{op.Authorize},
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.AllowTrust(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op AllowTrustOperationBody) Validate() error {
+	if !protocols.IsValidAssetCode(op.AssetCode) {
+		return protocols.NewInvalidParameterError("asset_code", op.AssetCode)
+	}
+
+	if !protocols.IsValidAccountID(op.Trustor) {
+		return protocols.NewInvalidParameterError("trustor", op.Trustor)
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_allow_trust.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_allow_trust.go
@@ -5,7 +5,7 @@ import (
 	b "github.com/stellar/go-stellar-base/build"
 )
 
-// AllowTrustOperationBody represents create_account operation
+// AllowTrustOperationBody represents allow_trust operation
 type AllowTrustOperationBody struct {
 	Source    *string
 	AssetCode string `json:"asset_code"`

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_change_trust.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_change_trust.go
@@ -1,0 +1,53 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// ChangeTrustOperationBody represents create_account operation
+type ChangeTrustOperationBody struct {
+	Source *string
+	Asset  protocols.Asset
+	// nil means max limit
+	Limit *string
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op ChangeTrustOperationBody) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{
+		op.Asset.ToBaseAsset(),
+	}
+
+	if op.Limit == nil {
+		// Set MaxLimit
+		mutators = append(mutators, b.MaxLimit)
+	} else {
+		mutators = append(mutators, b.Limit(*op.Limit))
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.ChangeTrust(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op ChangeTrustOperationBody) Validate() error {
+	if !op.Asset.Validate() {
+		return protocols.NewInvalidParameterError("asset", op.Asset.String())
+	}
+
+	if op.Limit != nil {
+		if !protocols.IsValidAmount(*op.Limit) {
+			return protocols.NewInvalidParameterError("limit", *op.Limit)
+		}
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_change_trust.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_change_trust.go
@@ -5,7 +5,7 @@ import (
 	b "github.com/stellar/go-stellar-base/build"
 )
 
-// ChangeTrustOperationBody represents create_account operation
+// ChangeTrustOperationBody represents change_trust operation
 type ChangeTrustOperationBody struct {
 	Source *string
 	Asset  protocols.Asset

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_create_account.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_create_account.go
@@ -1,0 +1,44 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// CreateAccountOperationBody represents create_account operation
+type CreateAccountOperationBody struct {
+	Source          *string
+	Destination     string
+	StartingBalance string `json:"starting_balance"`
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op CreateAccountOperationBody) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{
+		b.Destination{op.Destination},
+		b.NativeAmount{op.StartingBalance},
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.CreateAccount(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op CreateAccountOperationBody) Validate() error {
+	if !protocols.IsValidAccountID(op.Destination) {
+		return protocols.NewInvalidParameterError("destination", op.Destination)
+	}
+
+	if !protocols.IsValidAmount(op.StartingBalance) {
+		return protocols.NewInvalidParameterError("starting_balance", op.StartingBalance)
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_inflation.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_inflation.go
@@ -1,0 +1,31 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// InflationOperationBody represents inflation operation
+type InflationOperationBody struct {
+	Source *string
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op InflationOperationBody) ToTransactionMutator() b.TransactionMutator {
+	var mutators []interface{}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.Inflation(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op InflationOperationBody) Validate() error {
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_manage_data.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_manage_data.go
@@ -27,7 +27,7 @@ func (op ManageDataOperationBody) ToTransactionMutator() b.TransactionMutator {
 	}
 
 	if op.Source != nil {
-		builder.mutate(b.SourceAccount{*op.Source})
+		builder.Mutate(b.SourceAccount{*op.Source})
 	}
 
 	return builder

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_manage_data.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_manage_data.go
@@ -1,0 +1,52 @@
+package bridge
+
+import (
+	"encoding/base64"
+
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// ManageDataOperationBody represents manage_data operation
+type ManageDataOperationBody struct {
+	Source *string
+	Name   string
+	Data   string
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op ManageDataOperationBody) ToTransactionMutator() b.TransactionMutator {
+	var builder b.ManageDataBuilder
+
+	if op.Data == "" {
+		builder = b.ClearData(op.Name)
+	} else {
+		// This is validated in Validate()
+		data, _ := base64.StdEncoding.DecodeString(op.Data)
+		builder = b.SetData(op.Name, data)
+	}
+
+	if op.Source != nil {
+		builder.mutate(b.SourceAccount{*op.Source})
+	}
+
+	return builder
+}
+
+// Validate validates if operation body is valid.
+func (op ManageDataOperationBody) Validate() error {
+	if len(op.Name) > 64 {
+		return protocols.NewInvalidParameterError("name", op.Name)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(op.Data)
+	if err != nil || len(data) > 64 {
+		return protocols.NewInvalidParameterError("data", op.Data)
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_manage_offer.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_manage_offer.go
@@ -1,0 +1,47 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// ManageOfferOperationBody represents manage_offer operation
+type ManageOfferOperationBody struct {
+	Source  *string
+	Selling protocols.Asset
+	Buying  protocols.Asset
+	Amount  string
+	Price   string
+	OfferID *uint64 `json:"offer_id"`
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op ManageOfferOperationBody) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{
+		b.Amount(op.Amount),
+		b.Rate{
+			Selling: op.Selling.ToBaseAsset(),
+			Buying:  op.Buying.ToBaseAsset(),
+			Price:   op.Price,
+		},
+	}
+
+	if op.OfferID != nil {
+		mutators = append(mutators, b.OfferID{*op.OfferID})
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.ManageOffer(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op ManageOfferOperationBody) Validate() error {
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_path_payment.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_path_payment.go
@@ -7,7 +7,7 @@ import (
 	b "github.com/stellar/go-stellar-base/build"
 )
 
-// PathPaymentOperationBody represents payment operation
+// PathPaymentOperationBody represents path_payment operation
 type PathPaymentOperationBody struct {
 	Source *string
 

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_path_payment.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_path_payment.go
@@ -1,0 +1,96 @@
+package bridge
+
+import (
+	"strconv"
+
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// PathPaymentOperationBody represents payment operation
+type PathPaymentOperationBody struct {
+	Source *string
+
+	SendMax   string          `json:"send_max"`
+	SendAsset protocols.Asset `json:"send_asset"`
+
+	Destination       string
+	DestinationAmount string          `json:"destination_amount"`
+	DestinationAsset  protocols.Asset `json:"destination_asset"`
+
+	Path []protocols.Asset
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op PathPaymentOperationBody) ToTransactionMutator() b.TransactionMutator {
+	var path []b.Asset
+	for _, pathAsset := range op.Path {
+		path = append(path, pathAsset.ToBaseAsset())
+	}
+
+	mutators := []interface{}{
+		b.Destination{op.Destination},
+		b.PayWithPath{
+			Asset:     op.SendAsset.ToBaseAsset(),
+			MaxAmount: op.SendMax,
+			Path:      path,
+		},
+	}
+
+	if op.DestinationAsset.Code != "" && op.DestinationAsset.Issuer != "" {
+		mutators = append(
+			mutators,
+			b.CreditAmount{
+				op.DestinationAsset.Code,
+				op.DestinationAsset.Issuer,
+				op.DestinationAmount,
+			},
+		)
+	} else {
+		mutators = append(
+			mutators,
+			b.NativeAmount{op.DestinationAmount},
+		)
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.Payment(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op PathPaymentOperationBody) Validate() error {
+	if !protocols.IsValidAccountID(op.Destination) {
+		return protocols.NewInvalidParameterError("destination", op.Destination)
+	}
+
+	if !protocols.IsValidAmount(op.SendMax) {
+		return protocols.NewInvalidParameterError("send_max", op.SendMax)
+	}
+
+	if !protocols.IsValidAmount(op.DestinationAmount) {
+		return protocols.NewInvalidParameterError("destination_amount", op.DestinationAmount)
+	}
+
+	if !op.SendAsset.Validate() {
+		return protocols.NewInvalidParameterError("send_asset", op.SendAsset.String())
+	}
+
+	if !op.DestinationAsset.Validate() {
+		return protocols.NewInvalidParameterError("destination_asset", op.DestinationAsset.String())
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	for i, asset := range op.Path {
+		if !asset.Validate() {
+			return protocols.NewInvalidParameterError("path["+strconv.Itoa(i)+"]", asset.String())
+		}
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_payment.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_payment.go
@@ -1,0 +1,60 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// PaymentOperationBody represents payment operation
+type PaymentOperationBody struct {
+	Source      *string
+	Destination string
+	Amount      string
+	Asset       protocols.Asset
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op PaymentOperationBody) ToTransactionMutator() b.TransactionMutator {
+	mutators := []interface{}{
+		b.Destination{op.Destination},
+	}
+
+	if op.Asset.Code != "" && op.Asset.Issuer != "" {
+		mutators = append(
+			mutators,
+			b.CreditAmount{op.Asset.Code, op.Asset.Issuer, op.Amount},
+		)
+	} else {
+		mutators = append(
+			mutators,
+			b.NativeAmount{op.Amount},
+		)
+	}
+
+	if op.Source != nil {
+		mutators = append(mutators, b.SourceAccount{*op.Source})
+	}
+
+	return b.Payment(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op PaymentOperationBody) Validate() error {
+	if !protocols.IsValidAccountID(op.Destination) {
+		return protocols.NewInvalidParameterError("destination", op.Destination)
+	}
+
+	if !protocols.IsValidAmount(op.Amount) {
+		return protocols.NewInvalidParameterError("amount", op.Amount)
+	}
+
+	if !op.Asset.Validate() {
+		return protocols.NewInvalidParameterError("asset", op.Asset.String())
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_set_options.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_set_options.go
@@ -1,0 +1,92 @@
+package bridge
+
+import (
+	"github.com/stellar/gateway/protocols"
+	b "github.com/stellar/go-stellar-base/build"
+)
+
+// SetOptionsOperationBody represents set_options operation
+type SetOptionsOperationBody struct {
+	Source          *string
+	InflationDest   *string           `json:"inflation_dest"`
+	SetFlags        *[]int            `json:"set_flags"`
+	ClearFlags      *[]int            `json:"clear_flags"`
+	MasterWeight    *uint             `json:"master_flags"`
+	LowThreshold    *uint             `json:"low_threshold"`
+	MediumThreshold *uint             `json:"medium_threshold"`
+	HighThreshold   *uint             `json:"high_threshold"`
+	HomeDomain      *string           `json:"home_domain"`
+	Signer          *SetOptionsSigner `json:"signer"`
+}
+
+// SetOptionsSigner is a struct that representing signer in SetOptions operation body
+type SetOptionsSigner struct {
+	PublicKey string `json:"public_key"`
+	Weight    uint   `json:"weight"`
+}
+
+// ToTransactionMutator returns go-stellar-base TransactionMutator
+func (op SetOptionsOperationBody) ToTransactionMutator() b.TransactionMutator {
+	var mutators []interface{}
+
+	if op.InflationDest != nil {
+		mutators = append(mutators, b.InflationDest(*op.InflationDest))
+	}
+
+	if op.SetFlags != nil {
+		for _, flag := range *op.SetFlags {
+			mutators = append(mutators, b.SetFlag(flag))
+		}
+	}
+
+	if op.ClearFlags != nil {
+		for _, flag := range *op.ClearFlags {
+			mutators = append(mutators, b.ClearFlag(flag))
+		}
+	}
+
+	if op.MasterWeight != nil {
+		mutators = append(mutators, b.MasterWeight(*op.MasterWeight))
+	}
+
+	if op.LowThreshold != nil {
+		mutators = append(mutators, b.SetLowThreshold(*op.LowThreshold))
+	}
+
+	if op.MediumThreshold != nil {
+		mutators = append(mutators, b.SetMediumThreshold(*op.MediumThreshold))
+	}
+
+	if op.HighThreshold != nil {
+		mutators = append(mutators, b.SetHighThreshold(*op.HighThreshold))
+	}
+
+	if op.HomeDomain != nil {
+		mutators = append(mutators, b.HomeDomain(*op.HomeDomain))
+	}
+
+	if op.Signer != nil {
+		mutators = append(mutators, b.Signer(op.Signer))
+	}
+
+	return b.SetOptions(mutators...)
+}
+
+// Validate validates if operation body is valid.
+func (op SetOptionsOperationBody) Validate() error {
+	if op.InflationDest != nil && !protocols.IsValidAccountID(*op.InflationDest) {
+		return protocols.NewInvalidParameterError("inflation_dest", *op.InflationDest)
+	}
+
+	if op.Signer != nil {
+		if !protocols.IsValidAccountID(*op.Signer.PublicKey) {
+			return protocols.NewInvalidParameterError("signer.public_key", op.Signer.PublicKey)
+		}
+	}
+
+	if op.Source != nil && !protocols.IsValidAccountID(*op.Source) {
+		return protocols.NewInvalidParameterError("source", *op.Source)
+	}
+
+	return nil
+}

--- a/src/github.com/stellar/gateway/protocols/bridge/builder_set_options.go
+++ b/src/github.com/stellar/gateway/protocols/bridge/builder_set_options.go
@@ -11,10 +11,10 @@ type SetOptionsOperationBody struct {
 	InflationDest   *string           `json:"inflation_dest"`
 	SetFlags        *[]int            `json:"set_flags"`
 	ClearFlags      *[]int            `json:"clear_flags"`
-	MasterWeight    *uint             `json:"master_flags"`
-	LowThreshold    *uint             `json:"low_threshold"`
-	MediumThreshold *uint             `json:"medium_threshold"`
-	HighThreshold   *uint             `json:"high_threshold"`
+	MasterWeight    *uint32           `json:"master_weight"`
+	LowThreshold    *uint32           `json:"low_threshold"`
+	MediumThreshold *uint32           `json:"medium_threshold"`
+	HighThreshold   *uint32           `json:"high_threshold"`
 	HomeDomain      *string           `json:"home_domain"`
 	Signer          *SetOptionsSigner `json:"signer"`
 }
@@ -22,7 +22,7 @@ type SetOptionsOperationBody struct {
 // SetOptionsSigner is a struct that representing signer in SetOptions operation body
 type SetOptionsSigner struct {
 	PublicKey string `json:"public_key"`
-	Weight    uint   `json:"weight"`
+	Weight    uint32 `json:"weight"`
 }
 
 // ToTransactionMutator returns go-stellar-base TransactionMutator
@@ -66,7 +66,10 @@ func (op SetOptionsOperationBody) ToTransactionMutator() b.TransactionMutator {
 	}
 
 	if op.Signer != nil {
-		mutators = append(mutators, b.Signer(op.Signer))
+		mutators = append(mutators, b.Signer{
+			PublicKey: op.Signer.PublicKey,
+			Weight:    op.Signer.Weight,
+		})
 	}
 
 	return b.SetOptions(mutators...)
@@ -79,7 +82,7 @@ func (op SetOptionsOperationBody) Validate() error {
 	}
 
 	if op.Signer != nil {
-		if !protocols.IsValidAccountID(*op.Signer.PublicKey) {
+		if !protocols.IsValidAccountID(op.Signer.PublicKey) {
 			return protocols.NewInvalidParameterError("signer.public_key", op.Signer.PublicKey)
 		}
 	}

--- a/src/github.com/stellar/gateway/protocols/common.go
+++ b/src/github.com/stellar/gateway/protocols/common.go
@@ -7,12 +7,39 @@ import (
 	"reflect"
 
 	"github.com/facebookgo/structtag"
+	"github.com/stellar/go-stellar-base/build"
 )
 
-// Asset represents asset in responses
+// Asset represents native or credit asset
 type Asset struct {
-	Code   string `name:"asset_code"`
-	Issuer string `name:"asset_issuer"`
+	Code   string `name:"asset_code" json:"code"`
+	Issuer string `name:"asset_issuer" json:"issuer"`
+}
+
+// ToBaseAsset transforms Asset to github.com/stellar/go-stellar-base/build.Asset
+func (a Asset) ToBaseAsset() build.Asset {
+	if a.Code == "" && a.Issuer == "" {
+		return build.NativeAsset()
+	}
+	return build.CreditAsset(a.Code, a.Issuer)
+}
+
+// String returns string representation of this asset
+func (a Asset) String() string {
+	return fmt.Sprintf("%+v", a)
+}
+
+// Validate checks if asset params are correct.
+func (a Asset) Validate() bool {
+	if a.Code != "" && a.Issuer != "" {
+		// Credit
+		return IsValidAssetCode(a.Code) && IsValidAccountID(a.Issuer)
+	} else if a.Code == "" && a.Issuer == "" {
+		// Native
+		return true
+	} else {
+		return false
+	}
 }
 
 // FormRequest allows transforming http.Request url.Values from/to request structs

--- a/src/github.com/stellar/gateway/protocols/errors.go
+++ b/src/github.com/stellar/gateway/protocols/errors.go
@@ -26,13 +26,20 @@ func NewInternalServerError(logMessage string, logData map[string]interface{}) *
 }
 
 // NewInvalidParameterError creates and returns a new InvalidParameterError
-func NewInvalidParameterError(name, value string) *ErrorResponse {
+func NewInvalidParameterError(name, value string, additionalLogData ...map[string]interface{}) *ErrorResponse {
+	logData := map[string]interface{}{"name": name, "value": value}
+	if len(additionalLogData) == 1 {
+		for k, v := range additionalLogData[0] {
+			logData[k] = v
+		}
+	}
+
 	return &ErrorResponse{
 		Status:  InvalidParameterError.Status,
 		Code:    InvalidParameterError.Code,
 		Message: InvalidParameterError.Message,
 		Data:    map[string]interface{}{"name": name},
-		LogData: map[string]interface{}{"name": name, "value": value},
+		LogData: logData,
 	}
 }
 

--- a/src/github.com/stellar/gateway/protocols/validation.go
+++ b/src/github.com/stellar/gateway/protocols/validation.go
@@ -1,0 +1,32 @@
+package protocols
+
+import (
+	"github.com/stellar/go-stellar-base/amount"
+	"github.com/stellar/go-stellar-base/keypair"
+)
+
+// IsValidAccountID returns true if account ID is valid
+func IsValidAccountID(accountID string) bool {
+	_, err := keypair.Parse(accountID)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// IsValidAssetCode returns true if asset code is valid
+func IsValidAssetCode(code string) bool {
+	if len(code) < 1 || len(code) > 12 {
+		return false
+	}
+	return true
+}
+
+// IsValidAmount returns true if amount is valid
+func IsValidAmount(a string) bool {
+	_, err := amount.Parse(a)
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -254,7 +254,7 @@
 		{
 			"importpath": "github.com/stellar/go-stellar-base",
 			"repository": "https://github.com/stellar/go-stellar-base",
-			"revision": "6ec1f1dfe3f3a623365d3f77217a7d627b6e2ed1",
+			"revision": "3b1ac79285380d07ed8ed6e7d3f87d8eb21b999e",
 			"branch": "master"
 		},
 		{

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -254,7 +254,7 @@
 		{
 			"importpath": "github.com/stellar/go-stellar-base",
 			"repository": "https://github.com/stellar/go-stellar-base",
-			"revision": "1b1fa3d84248a24a6fea8860636a62e626e3dfff",
+			"revision": "6ec1f1dfe3f3a623365d3f77217a7d627b6e2ed1",
 			"branch": "master"
 		},
 		{

--- a/vendor/src/github.com/stellar/go-stellar-base/Gemfile
+++ b/vendor/src/github.com/stellar/go-stellar-base/Gemfile
@@ -2,3 +2,4 @@ gem 'xdrgen', path: File.expand_path("~/src/stellar/xdrgen")
 gem 'pry'
 gem 'octokit'
 gem 'netrc'
+gem 'rake'

--- a/vendor/src/github.com/stellar/go-stellar-base/Rakefile
+++ b/vendor/src/github.com/stellar/go-stellar-base/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler'
 Bundler.setup()
+require 'pry'
 
 namespace :xdr do
 

--- a/vendor/src/github.com/stellar/go-stellar-base/build/account_merge.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/account_merge.go
@@ -1,0 +1,52 @@
+package build
+
+import (
+	"errors"
+
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// AccountMerge groups the creation of a new AccountMergeBuilder with a call to Mutate.
+func AccountMerge(muts ...interface{}) (result AccountMergeBuilder) {
+	result.Mutate(muts...)
+	return
+}
+
+// AccountMergeMutator is a interface that wraps the
+// MutateAccountMerge operation.  types may implement this interface to
+// specify how they modify an xdr.AccountMergeBuilder object
+type AccountMergeMutator interface {
+	MutateAccountMerge(*AccountMergeBuilder) error
+}
+
+// AccountMergeBuilder represents a transaction that is being built.
+type AccountMergeBuilder struct {
+	O           xdr.Operation
+	Destination xdr.AccountId
+	Err         error
+}
+
+// Mutate applies the provided mutators to this builder's payment or operation.
+func (b *AccountMergeBuilder) Mutate(muts ...interface{}) {
+	for _, m := range muts {
+		var err error
+		switch mut := m.(type) {
+		case AccountMergeMutator:
+			err = mut.MutateAccountMerge(b)
+		case OperationMutator:
+			err = mut.MutateOperation(&b.O)
+		default:
+			err = errors.New("Mutator type not allowed")
+		}
+
+		if err != nil {
+			b.Err = err
+			return
+		}
+	}
+}
+
+// MutateAccountMerge for Destination sets the AccountMergeBuilder's Destination field
+func (m Destination) MutateAccountMerge(o *AccountMergeBuilder) error {
+	return setAccountId(m.AddressOrSeed, &o.Destination)
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/build/account_merge_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/account_merge_test.go
@@ -1,0 +1,65 @@
+package build
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stellar/go-stellar-base"
+)
+
+var _ = Describe("AccountMergeBuilder Mutators", func() {
+
+	var (
+		subject AccountMergeBuilder
+		mut     interface{}
+
+		address = "GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ"
+		bad     = "foo"
+	)
+
+	JustBeforeEach(func() {
+		subject = AccountMergeBuilder{}
+		subject.Mutate(mut)
+	})
+
+	Describe("Destination", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = Destination{address} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.Destination.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = Destination{bad} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("SourceAccount", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = SourceAccount{address} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.O.SourceAccount.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = SourceAccount{bad} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	//
+})

--- a/vendor/src/github.com/stellar/go-stellar-base/build/allow_trust.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/allow_trust.go
@@ -13,7 +13,7 @@ func AllowTrust(muts ...interface{}) (result AllowTrustBuilder) {
 }
 
 // AllowTrustMutator is a interface that wraps the
-// MutatePayment operation.  types may implement this interface to
+// MutateAllowTrust operation.  types may implement this interface to
 // specify how they modify an xdr.AllowTrustOp object
 type AllowTrustMutator interface {
 	MutateAllowTrust(*xdr.AllowTrustOp) error

--- a/vendor/src/github.com/stellar/go-stellar-base/build/change_trust.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/change_trust.go
@@ -14,7 +14,7 @@ func ChangeTrust(muts ...interface{}) (result ChangeTrustBuilder) {
 }
 
 // ChangeTrustMutator is a interface that wraps the
-// MutatePayment operation.  types may implement this interface to
+// MutateChangeTrust operation.  types may implement this interface to
 // specify how they modify an xdr.ChangeTrustOp object
 type ChangeTrustMutator interface {
 	MutateChangeTrust(*xdr.ChangeTrustOp) error
@@ -53,7 +53,7 @@ func (m Asset) MutateChangeTrust(o *xdr.ChangeTrustOp) (err error) {
 		return errors.New("Native asset not allowed")
 	}
 
-	o.Line, err = createAlphaNumAsset(m.Code, m.Issuer)
+	o.Line, err = m.ToXdrObject()
 	return
 }
 

--- a/vendor/src/github.com/stellar/go-stellar-base/build/change_trust.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/change_trust.go
@@ -1,0 +1,101 @@
+package build
+
+import (
+	"errors"
+
+	"github.com/stellar/go-stellar-base/amount"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// ChangeTrust groups the creation of a new ChangeTrustBuilder with a call to Mutate.
+func ChangeTrust(muts ...interface{}) (result ChangeTrustBuilder) {
+	result.Mutate(muts...)
+	return
+}
+
+// ChangeTrustMutator is a interface that wraps the
+// MutatePayment operation.  types may implement this interface to
+// specify how they modify an xdr.ChangeTrustOp object
+type ChangeTrustMutator interface {
+	MutateChangeTrust(*xdr.ChangeTrustOp) error
+}
+
+// ChangeTrustBuilder represents a transaction that is being built.
+type ChangeTrustBuilder struct {
+	O   xdr.Operation
+	CT  xdr.ChangeTrustOp
+	Err error
+}
+
+// Mutate applies the provided mutators to this builder's payment or operation.
+func (b *ChangeTrustBuilder) Mutate(muts ...interface{}) {
+	for _, m := range muts {
+		var err error
+		switch mut := m.(type) {
+		case ChangeTrustMutator:
+			err = mut.MutateChangeTrust(&b.CT)
+		case OperationMutator:
+			err = mut.MutateOperation(&b.O)
+		default:
+			err = errors.New("Mutator type not allowed")
+		}
+
+		if err != nil {
+			b.Err = err
+			return
+		}
+	}
+}
+
+// MutateChangeTrust for Asset sets the ChangeTrustOp's Line field
+func (m Asset) MutateChangeTrust(o *xdr.ChangeTrustOp) (err error) {
+	if m.Native {
+		return errors.New("Native asset not allowed")
+	}
+
+	o.Line, err = createAlphaNumAsset(m.Code, m.Issuer)
+	return
+}
+
+// MutateChangeTrust for Limit sets the ChangeTrustOp's Limit field
+func (m Limit) MutateChangeTrust(o *xdr.ChangeTrustOp) (err error) {
+	o.Limit, err = amount.Parse(string(m))
+	return
+}
+
+// Trust is a helper that creates ChangeTrustBuilder
+func Trust(code, issuer string, args ...interface{}) (result ChangeTrustBuilder) {
+	mutators := []interface{}{
+		CreditAsset(code, issuer),
+	}
+
+	limitSet := false
+
+	for _, mut := range args {
+		mutators = append(mutators, mut)
+		_, isLimit := mut.(Limit)
+		if isLimit {
+			limitSet = true
+		}
+	}
+
+	if !limitSet {
+		mutators = append(mutators, MaxLimit)
+	}
+
+	return ChangeTrust(mutators...)
+}
+
+// RemoveTrust is a helper that creates ChangeTrustBuilder
+func RemoveTrust(code, issuer string, args ...interface{}) (result ChangeTrustBuilder) {
+	mutators := []interface{}{
+		CreditAsset(code, issuer),
+		Limit("0"),
+	}
+
+	for _, mut := range args {
+		mutators = append(mutators, mut)
+	}
+
+	return ChangeTrust(mutators...)
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/build/change_trust_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/change_trust_test.go
@@ -1,0 +1,134 @@
+package build
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stellar/go-stellar-base"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+var _ = Describe("ChangeTrustBuilder Mutators", func() {
+
+	var (
+		subject ChangeTrustBuilder
+		mut     interface{}
+
+		address = "GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ"
+		bad     = "foo"
+	)
+
+	JustBeforeEach(func() {
+		subject = ChangeTrustBuilder{}
+		subject.Mutate(mut)
+	})
+
+	Describe("SourceAccount", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = SourceAccount{address} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.O.SourceAccount.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = SourceAccount{bad} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("Line", func() {
+		Context("AssetTypeCreditAlphanum4", func() {
+			BeforeEach(func() {
+				mut = CreditAsset("USD", address)
+			})
+
+			It("sets Asset properly", func() {
+				Expect(subject.CT.Line.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
+				Expect(subject.CT.Line.AlphaNum4.AssetCode).To(Equal([4]byte{'U', 'S', 'D', 0}))
+				Expect(subject.CT.Line.AlphaNum12).To(BeNil())
+			})
+		})
+
+		Context("AssetTypeCreditAlphanum12", func() {
+			BeforeEach(func() {
+				mut = CreditAsset("ABCDEF", address)
+			})
+
+			It("sets Asset properly", func() {
+				Expect(subject.CT.Line.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum12))
+				Expect(subject.CT.Line.AlphaNum4).To(BeNil())
+				Expect(subject.CT.Line.AlphaNum12.AssetCode).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
+			})
+		})
+
+		Context("asset invalid", func() {
+			Context("native", func() {
+				BeforeEach(func() {
+					mut = NativeAsset()
+				})
+
+				It("failed", func() {
+					Expect(subject.Err).To(MatchError("Native asset not allowed"))
+				})
+			})
+
+			Context("empty", func() {
+				BeforeEach(func() {
+					mut = CreditAsset("", address)
+				})
+
+				It("failed", func() {
+					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+				})
+			})
+
+			Context("too long", func() {
+				BeforeEach(func() {
+					mut = CreditAsset("1234567890123", address)
+				})
+
+				It("failed", func() {
+					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+				})
+			})
+		})
+
+		Context("issuer invalid", func() {
+			BeforeEach(func() {
+				mut = CreditAsset("USD", bad)
+			})
+
+			It("failed", func() {
+				Expect(subject.Err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Limit", func() {
+		Context("sets limit properly", func() {
+			BeforeEach(func() {
+				mut = Limit("20")
+			})
+
+			It("sets limit value properly", func() {
+				Expect(subject.CT.Limit).To(Equal(xdr.Int64(200000000)))
+			})
+		})
+
+		Context("sets max limit properly", func() {
+			BeforeEach(func() {
+				mut = MaxLimit
+			})
+
+			It("sets limit value properly", func() {
+				Expect(subject.CT.Limit).To(Equal(xdr.Int64(9223372036854775807)))
+			})
+		})
+	})
+})

--- a/vendor/src/github.com/stellar/go-stellar-base/build/create_account.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/create_account.go
@@ -15,7 +15,7 @@ func CreateAccount(muts ...interface{}) (result CreateAccountBuilder) {
 }
 
 // CreateAccountMutator is a interface that wraps the
-// MutatePayment operation.  types may implement this interface to
+// MutateCreateAccount operation.  types may implement this interface to
 // specify how they modify an xdr.PaymentOp object
 type CreateAccountMutator interface {
 	MutateCreateAccount(*xdr.CreateAccountOp) error

--- a/vendor/src/github.com/stellar/go-stellar-base/build/inflation.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/inflation.go
@@ -1,0 +1,37 @@
+package build
+
+import (
+	"errors"
+
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// Inflation groups the creation of a new InflationBuilder with a call to Mutate.
+func Inflation(muts ...interface{}) (result InflationBuilder) {
+	result.Mutate(muts...)
+	return
+}
+
+// InflationBuilder represents an operation that is being built.
+type InflationBuilder struct {
+	O   xdr.Operation
+	Err error
+}
+
+// Mutate applies the provided mutators to this builder's operation.
+func (b *InflationBuilder) Mutate(muts ...interface{}) {
+	for _, m := range muts {
+		var err error
+		switch mut := m.(type) {
+		case OperationMutator:
+			err = mut.MutateOperation(&b.O)
+		default:
+			err = errors.New("Mutator type not allowed")
+		}
+
+		if err != nil {
+			b.Err = err
+			return
+		}
+	}
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/build/inflation_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/inflation_test.go
@@ -1,0 +1,43 @@
+package build
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stellar/go-stellar-base"
+)
+
+var _ = Describe("InflationBuilder Mutators", func() {
+
+	var (
+		subject InflationBuilder
+		mut     interface{}
+
+		address = "GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ"
+		bad     = "foo"
+	)
+
+	JustBeforeEach(func() {
+		subject = InflationBuilder{}
+		subject.Mutate(mut)
+	})
+
+	Describe("SourceAccount", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = SourceAccount{address} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.O.SourceAccount.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = SourceAccount{bad} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+})

--- a/vendor/src/github.com/stellar/go-stellar-base/build/main.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/main.go
@@ -8,6 +8,9 @@
 package build
 
 import (
+	"math"
+
+	"github.com/stellar/go-stellar-base/amount"
 	"github.com/stellar/go-stellar-base/network"
 	"github.com/stellar/go-stellar-base/xdr"
 )
@@ -34,6 +37,9 @@ var (
 	DefaultNetwork = TestNetwork
 )
 
+// Amount is a mutator capable of setting the amount
+type Amount string
+
 // Asset is struct used in path_payment mutators
 type Asset struct {
 	Code   string
@@ -52,12 +58,12 @@ type Authorize struct {
 	Value bool
 }
 
-// Helper method to create native Asset object
+// NativeAsset is a helper method to create native Asset object
 func NativeAsset() Asset {
 	return Asset{Native: true}
 }
 
-// Helper method to create credit Asset object
+// CreditAsset is a helper method to create credit Asset object
 func CreditAsset(code, issuer string) Asset {
 	return Asset{code, issuer, false}
 }
@@ -85,6 +91,12 @@ type MemoHash struct {
 	Value xdr.Hash
 }
 
+// Limit is a mutator that sets a limit on the change_trust operation
+type Limit Amount
+
+// MaxLimit represents the maximum value that can be passed as trutline Limit
+var MaxLimit = Limit(amount.String(math.MaxInt64))
+
 // MemoID is a mutator that sets a memo on the mutated transaction of type
 // MEMO_ID.
 type MemoID struct {
@@ -109,18 +121,20 @@ type NativeAmount struct {
 	Amount string
 }
 
-// PathSend is a mutator that configures a path_payment's send asset and max amount
+// PayWithPath is a mutator that configures a path_payment's send asset and max amount
 type PayWithPath struct {
 	Asset
 	MaxAmount string
 	Path      []Asset
 }
 
+// Through appends a new asset to the path
 func (pathSend PayWithPath) Through(asset Asset) PayWithPath {
 	pathSend.Path = append(pathSend.Path, asset)
 	return pathSend
 }
 
+// PayWith is a helper to create PayWithPath struct
 func PayWith(sendAsset Asset, maxAmount string) PayWithPath {
 	return PayWithPath{
 		Asset:     sendAsset,

--- a/vendor/src/github.com/stellar/go-stellar-base/build/main_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/main_test.go
@@ -58,6 +58,62 @@ func ExamplePathPayment() {
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAIAAAABRVVSAAAAAACflO2Jhs1DJkFfo7YvGZeKqpze+F4ENZde22bePZeubwAAAAA7msoAAAAAAEc9q5pbnyO0BDkT4FXgGhPGAj7kCKVbS4PDJS8D1pVCAAAAAVVTRAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAHc1lAAAAAAIAAAAAAAAAAUJUQwAAAAAADpyeqirBMAJpPzwvuVrLqxHz5shND7/OFUvopGIhupYAAAAAAAAAARtDMfAAAABA5xuIJu/KGKQRuDrdkzNsR4HjT6wX464SHZ/yvYwVb/AkAyyfeMLDNhgKbBxQMWc3Uo5fTst1UHldC+jYNeAhCQ==
 }
 
+// ExampleSetOptions creates and signs a simple transaction with SetOptions operation, and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleSetOptions() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		SetOptions(
+			InflationDest("GCT7S5BA6ZC7SV7GGEMEYJTWOBYTBOA7SC4JEYP7IAEDG7HQNIWKRJ4G"),
+			SetAuthRequired(),
+			SetAuthRevocable(),
+			SetAuthImmutable(),
+			ClearAuthRequired(),
+			ClearAuthRevocable(),
+			ClearAuthImmutable(),
+			MasterWeight(1),
+			SetThresholds(2, 3, 4),
+			HomeDomain("stellar.org"),
+			AddSigner("GC6DDGPXVWXD5V6XOWJ7VUTDYI7VKPV2RAJWBVBHR47OPV5NASUNHTJW", 5),
+		),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAUAAAABAAAAAKf5dCD2RflX5jEYTCZ2cHEwuB+QuJJh/0AIM3zwaiyoAAAAAQAAAAcAAAABAAAABwAAAAEAAAABAAAAAQAAAAIAAAABAAAAAwAAAAEAAAAEAAAAAQAAAAtzdGVsbGFyLm9yZwAAAAABAAAAALwxmfetrj7X13WT+tJjwj9VPrqIE2DUJ48+59etBKjTAAAABQAAAAAAAAABG0Mx8AAAAECZF17pOfZcyc7YJXMyx++PMydIvL6g2yZcPDY8h4+tmlz+3rsE6uuX0R6xfgNnuMntvK4YMmaOvp4DvaZMMNoA
+}
+
+// ExampleSetOptionsOperations creates and signs a simple transaction with many SetOptions operations, and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleSetOptionsOperations() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		InflationDest("GCT7S5BA6ZC7SV7GGEMEYJTWOBYTBOA7SC4JEYP7IAEDG7HQNIWKRJ4G"),
+		SetAuthRequired(),
+		SetAuthRevocable(),
+		SetAuthImmutable(),
+		ClearAuthRequired(),
+		ClearAuthRevocable(),
+		ClearAuthImmutable(),
+		MasterWeight(1),
+		SetThresholds(2, 3, 4),
+		HomeDomain("stellar.org"),
+		RemoveSigner("GC6DDGPXVWXD5V6XOWJ7VUTDYI7VKPV2RAJWBVBHR47OPV5NASUNHTJW"),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAETAAAAAAAAAABAAAAAAAAAAAAAAALAAAAAAAAAAUAAAABAAAAAKf5dCD2RflX5jEYTCZ2cHEwuB+QuJJh/0AIM3zwaiyoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAQAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAQAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAEAAAADAAAAAQAAAAQAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAALc3RlbGxhci5vcmcAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAALwxmfetrj7X13WT+tJjwj9VPrqIE2DUJ48+59etBKjTAAAAAAAAAAAAAAABG0Mx8AAAAEAOXsLbFo3e8fpqyeZEHGP9o/IrQDQRyof+DA1EeUkvUGbNhy57xXcpMhZpRtwXThWBYx4za4q+TRrnoZQtezgN
+}
+
 // ExampleChangeTrust creates and signs a simple transaction with ChangeTrust operation, and then
 // encodes it into a base64 string capable of being submitted to stellar-core.
 func ExampleChangeTrust() {
@@ -112,4 +168,88 @@ func ExampleRemoveTrust() {
 
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAQAAAACqkTaHkZTphDK+U/SnLXSJrA2mitA3sgOhIWTCRPQzIQAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAAAAAAAAAAAAAAAAAEbQzHwAAAAQD5FeGBEwJyeauK+WKfcxYBeKw62EtCqvC0p9Z+1cY32fKQ+5Jz9uE1LaDsHW5NurtStKcUTiG5j2qNDf1QpYgw=
+}
+
+// ExampleManageOffer creates and signs a simple transaction with ManageOffer operations, and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleManageOffer() {
+	rate := Rate{
+		Selling: NativeAsset(),
+		Buying:  CreditAsset("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"),
+		Price:   Price("125.12"),
+	}
+
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		CreateOffer(rate, "20"),
+		UpdateOffer(rate, "40", OfferID(2)),
+		DeleteOffer(rate, OfferID(1)),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAABLAAAAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAAMAAAAAAAAAAVVTRAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAC+vCAAAADDgAAAAZAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAAX14QAAAAMOAAAABkAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAFVU0QAAAAAAC0kaS7Qi79nm6GZRIhw0hkeh2/s2S/dn20nTaTm3hNBAAAAAAAAAAAAAAw4AAAAGQAAAAAAAAABAAAAAAAAAAEbQzHwAAAAQBfosk+t8qpULHP4ppNX2xVPih8lmnbHFZdeuxSP6pgpCCX05S7zZ4PsjVQY2nOnLru6mBTc1r8So+vxHs3FXAc=
+}
+
+// ExampleCreatePassiveOffer creates and signs a simple transaction with CreatePassiveOffer operation, and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleCreatePassiveOffer() {
+	rate := Rate{
+		Selling: NativeAsset(),
+		Buying:  CreditAsset("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"),
+		Price:   Price("125.12"),
+	}
+
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		CreatePassiveOffer(rate, "20"),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAQAAAAAAAAAAVVTRAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAC+vCAAAADDgAAAAZAAAAAAAAAAEbQzHwAAAAQHv/1xLn+ArfIUoWjn3V0zVka6tulqMYx4zJZhGqdmTw8iCXY0ZtHS+y+7YGgR3vM1DpKOdvWTmhee+sCXIppQA=
+}
+
+// ExampleAccountMerge creates and signs a simple transaction with AccountMerge operation, and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleAccountMerge() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		AccountMerge(
+			Destination{"GBDT3K42LOPSHNAEHEJ6AVPADIJ4MAR64QEKKW2LQPBSKLYD22KUEH4P"},
+		),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAgAAAAARz2rmlufI7QEORPgVeAaE8YCPuQIpVtLg8MlLwPWlUIAAAAAAAAAARtDMfAAAABAh3qZrP5T9Xg0LdzwOLx/eA/B7bzj+8j+s9eXNuu7/Ldch7I6kW5iYz6Vfy32FVnKNtoykToB7nQY2o2vo1tqAw==
+}
+
+// ExampleInflation creates and signs a simple transaction with Inflation operation, and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleInflation() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		Inflation(),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAkAAAAAAAAAARtDMfAAAABAzzDG4V7KzynWY0ER/V4HH0WgDvl3hrIizDcKW3qEQY4Ib3yXufVvdbzsET/Dj5js5dgDkcYgikHwRCpqi/J8BQ==
 }

--- a/vendor/src/github.com/stellar/go-stellar-base/build/main_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/main_test.go
@@ -57,3 +57,59 @@ func ExamplePathPayment() {
 	fmt.Printf("tx base64: %s", txeB64)
 	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAIAAAABRVVSAAAAAACflO2Jhs1DJkFfo7YvGZeKqpze+F4ENZde22bePZeubwAAAAA7msoAAAAAAEc9q5pbnyO0BDkT4FXgGhPGAj7kCKVbS4PDJS8D1pVCAAAAAVVTRAAAAAAALSRpLtCLv2eboZlEiHDSGR6Hb+zZL92fbSdNpObeE0EAAAAAHc1lAAAAAAIAAAAAAAAAAUJUQwAAAAAADpyeqirBMAJpPzwvuVrLqxHz5shND7/OFUvopGIhupYAAAAAAAAAARtDMfAAAABA5xuIJu/KGKQRuDrdkzNsR4HjT6wX464SHZ/yvYwVb/AkAyyfeMLDNhgKbBxQMWc3Uo5fTst1UHldC+jYNeAhCQ==
 }
+
+// ExampleChangeTrust creates and signs a simple transaction with ChangeTrust operation, and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleChangeTrust() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		Trust("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA", Limit("100.25")),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAA7wO+gAAAAAAAAAAEbQzHwAAAAQOIy19X38Y3jcFzvhDsmXu6iDzrzb4iwfS2NAq9GGAFiRJUGoFX85vKtlNcXzQppF4X8oIMNPEb74fuZE/N+GAE=
+}
+
+// ExampleChangeTrustMaxLimit creates and signs a simple transaction with ChangeTrust operation (maximum limit), and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleChangeTrustMaxLimit() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		Trust("USD", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQX//////////AAAAAAAAAAEbQzHwAAAAQJQC6R3RqNaw5rOmaxqpAE0lD5onM/njn9I2RVlhtS2SGi2Z7xm65USYVWXTJFVqTCfTwwu+QXFcOuqgJjVtHAk=
+}
+
+// ExampleRemoveTrust creates and signs a simple transaction with ChangeTrust operation (remove trust), and then
+// encodes it into a base64 string capable of being submitted to stellar-core.
+func ExampleRemoveTrust() {
+	seed := "SDOTALIMPAM2IV65IOZA7KZL7XWZI5BODFXTRVLIHLQZQCKK57PH5F3H"
+	operationSource := "GCVJCNUHSGKOTBBSXZJ7JJZNOSE2YDNGRLIDPMQDUEQWJQSE6QZSDPNU"
+	tx := Transaction(
+		SourceAccount{seed},
+		Sequence{1},
+		RemoveTrust(
+			"USD",
+			"GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA",
+			SourceAccount{operationSource},
+		),
+	)
+
+	txe := tx.Sign(seed)
+	txeB64, _ := txe.Base64()
+
+	fmt.Printf("tx base64: %s", txeB64)
+	// Output: tx base64: AAAAADZY/nWY0gx6beMpf4S8Ur0qHsjA8fbFtBzBx1cbQzHwAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAQAAAACqkTaHkZTphDK+U/SnLXSJrA2mitA3sgOhIWTCRPQzIQAAAAYAAAABVVNEAAAAAAAtJGku0Iu/Z5uhmUSIcNIZHodv7Nkv3Z9tJ02k5t4TQQAAAAAAAAAAAAAAAAAAAAEbQzHwAAAAQD5FeGBEwJyeauK+WKfcxYBeKw62EtCqvC0p9Z+1cY32fKQ+5Jz9uE1LaDsHW5NurtStKcUTiG5j2qNDf1QpYgw=
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/build/manage_offer.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/manage_offer.go
@@ -1,0 +1,133 @@
+package build
+
+import (
+	"errors"
+
+	"github.com/stellar/go-stellar-base/amount"
+	"github.com/stellar/go-stellar-base/price"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// CreateOffer creates a new offer
+func CreateOffer(rate Rate, amount Amount) (result ManageOfferBuilder) {
+	return ManageOffer(false, rate, amount)
+}
+
+// CreatePassiveOffer creates a new passive offer
+func CreatePassiveOffer(rate Rate, amount Amount) (result ManageOfferBuilder) {
+	return ManageOffer(true, rate, amount)
+}
+
+// UpdateOffer updates an existing offer
+func UpdateOffer(rate Rate, amount Amount, offerID OfferID) (result ManageOfferBuilder) {
+	return ManageOffer(false, rate, amount, offerID)
+}
+
+// DeleteOffer deletes an existing offer
+func DeleteOffer(rate Rate, offerID OfferID) (result ManageOfferBuilder) {
+	return ManageOffer(false, rate, Amount("0"), offerID)
+}
+
+// ManageOffer groups the creation of a new ManageOfferBuilder with a call to Mutate.
+func ManageOffer(passiveOffer bool, muts ...interface{}) (result ManageOfferBuilder) {
+	result.PassiveOffer = passiveOffer
+	result.Mutate(muts...)
+	return
+}
+
+// ManageOfferMutator is a interface that wraps the
+// MutateManageOffer operation.  types may implement this interface to
+// specify how they modify an xdr.ManageOfferOp object
+type ManageOfferMutator interface {
+	MutateManageOffer(interface{}) error
+}
+
+// ManageOfferBuilder represents a transaction that is being built.
+type ManageOfferBuilder struct {
+	PassiveOffer bool
+	O            xdr.Operation
+	MO           xdr.ManageOfferOp
+	PO           xdr.CreatePassiveOfferOp
+	Err          error
+}
+
+// Mutate applies the provided mutators to this builder's offer or operation.
+func (b *ManageOfferBuilder) Mutate(muts ...interface{}) {
+	for _, m := range muts {
+		var err error
+		switch mut := m.(type) {
+		case ManageOfferMutator:
+			if b.PassiveOffer {
+				err = mut.MutateManageOffer(&b.PO)
+			} else {
+				err = mut.MutateManageOffer(&b.MO)
+			}
+		case OperationMutator:
+			err = mut.MutateOperation(&b.O)
+		default:
+			err = errors.New("Mutator type not allowed")
+		}
+
+		if err != nil {
+			b.Err = err
+			return
+		}
+	}
+}
+
+// MutateManageOffer for Amount sets the ManageOfferOp's Amount field
+func (m Amount) MutateManageOffer(o interface{}) (err error) {
+	switch o := o.(type) {
+	default:
+		err = errors.New("Unexpected operation type")
+	case *xdr.ManageOfferOp:
+		o.Amount, err = amount.Parse(string(m))
+	case *xdr.CreatePassiveOfferOp:
+		o.Amount, err = amount.Parse(string(m))
+	}
+	return
+}
+
+// MutateManageOffer for OfferID sets the ManageOfferOp's OfferID field
+func (m OfferID) MutateManageOffer(o interface{}) (err error) {
+	switch o := o.(type) {
+	default:
+		err = errors.New("Unexpected operation type")
+	case *xdr.ManageOfferOp:
+		o.OfferId = xdr.Uint64(m)
+	}
+	return
+}
+
+// MutateManageOffer for Rate sets the ManageOfferOp's selling, buying and price fields
+func (m Rate) MutateManageOffer(o interface{}) (err error) {
+	switch o := o.(type) {
+	default:
+		err = errors.New("Unexpected operation type")
+	case *xdr.ManageOfferOp:
+		o.Selling, err = m.Selling.ToXdrObject()
+		if err != nil {
+			return
+		}
+
+		o.Buying, err = m.Buying.ToXdrObject()
+		if err != nil {
+			return
+		}
+
+		o.Price, err = price.Parse(string(m.Price))
+	case *xdr.CreatePassiveOfferOp:
+		o.Selling, err = m.Selling.ToXdrObject()
+		if err != nil {
+			return
+		}
+
+		o.Buying, err = m.Buying.ToXdrObject()
+		if err != nil {
+			return
+		}
+
+		o.Price, err = price.Parse(string(m.Price))
+	}
+	return
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/build/manage_offer_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/manage_offer_test.go
@@ -1,0 +1,168 @@
+package build
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stellar/go-stellar-base"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+var _ = Describe("ManageOffer", func() {
+
+	Describe("ManageOfferBuilder", func() {
+		var (
+			subject ManageOfferBuilder
+			mut     interface{}
+
+			address = "GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ"
+			bad     = "foo"
+
+			rate = Rate{
+				Selling: CreditAsset("EUR", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"),
+				Buying:  NativeAsset(),
+				Price:   Price("41.265"),
+			}
+		)
+
+		JustBeforeEach(func() {
+			subject = ManageOfferBuilder{}
+			subject.Mutate(mut)
+		})
+
+		Describe("CreateOffer", func() {
+			Context("creates offer properly", func() {
+				It("sets values properly", func() {
+					builder := CreateOffer(rate, "20")
+
+					Expect(builder.MO.Amount).To(Equal(xdr.Int64(200000000)))
+
+					Expect(builder.MO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
+					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					aid, _ := stellarbase.AddressToAccountId(rate.Selling.Issuer)
+					Expect(builder.MO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
+					Expect(builder.MO.Selling.AlphaNum12).To(BeNil())
+
+					Expect(builder.MO.Buying.Type).To(Equal(xdr.AssetTypeAssetTypeNative))
+					Expect(builder.MO.Buying.AlphaNum4).To(BeNil())
+					Expect(builder.MO.Buying.AlphaNum12).To(BeNil())
+
+					Expect(builder.MO.Price.N).To(Equal(xdr.Int32(8253)))
+					Expect(builder.MO.Price.D).To(Equal(xdr.Int32(200)))
+
+					Expect(builder.MO.OfferId).To(Equal(xdr.Uint64(0)))
+				})
+			})
+		})
+
+		Describe("UpdateOffer", func() {
+			Context("updates the offer properly", func() {
+				It("sets values properly", func() {
+					builder := UpdateOffer(rate, "100", 5)
+
+					Expect(builder.MO.Amount).To(Equal(xdr.Int64(1000000000)))
+
+					Expect(builder.MO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
+					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					aid, _ := stellarbase.AddressToAccountId(rate.Selling.Issuer)
+					Expect(builder.MO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
+					Expect(builder.MO.Selling.AlphaNum12).To(BeNil())
+
+					Expect(builder.MO.Buying.Type).To(Equal(xdr.AssetTypeAssetTypeNative))
+					Expect(builder.MO.Buying.AlphaNum4).To(BeNil())
+					Expect(builder.MO.Buying.AlphaNum12).To(BeNil())
+
+					Expect(builder.MO.Price.N).To(Equal(xdr.Int32(8253)))
+					Expect(builder.MO.Price.D).To(Equal(xdr.Int32(200)))
+
+					Expect(builder.MO.OfferId).To(Equal(xdr.Uint64(5)))
+				})
+			})
+		})
+
+		Describe("DeleteOffer", func() {
+			Context("deletes the offer properly", func() {
+				It("sets values properly", func() {
+					builder := DeleteOffer(rate, 10)
+
+					Expect(builder.MO.Amount).To(Equal(xdr.Int64(0)))
+
+					Expect(builder.MO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
+					Expect(builder.MO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					aid, _ := stellarbase.AddressToAccountId(rate.Selling.Issuer)
+					Expect(builder.MO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
+					Expect(builder.MO.Selling.AlphaNum12).To(BeNil())
+
+					Expect(builder.MO.Buying.Type).To(Equal(xdr.AssetTypeAssetTypeNative))
+					Expect(builder.MO.Buying.AlphaNum4).To(BeNil())
+					Expect(builder.MO.Buying.AlphaNum12).To(BeNil())
+
+					Expect(builder.MO.Price.N).To(Equal(xdr.Int32(8253)))
+					Expect(builder.MO.Price.D).To(Equal(xdr.Int32(200)))
+
+					Expect(builder.MO.OfferId).To(Equal(xdr.Uint64(10)))
+				})
+			})
+		})
+
+		Describe("SourceAccount", func() {
+			Context("using a valid stellar address", func() {
+				BeforeEach(func() { mut = SourceAccount{address} })
+
+				It("succeeds", func() {
+					Expect(subject.Err).NotTo(HaveOccurred())
+				})
+
+				It("sets the destination to the correct xdr.AccountId", func() {
+					aid, _ := stellarbase.AddressToAccountId(address)
+					Expect(subject.O.SourceAccount.MustEd25519()).To(Equal(aid.MustEd25519()))
+				})
+			})
+
+			Context("using an invalid value", func() {
+				BeforeEach(func() { mut = SourceAccount{bad} })
+				It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+			})
+		})
+	})
+
+	Describe("CreatePassiveOfferBuilder", func() {
+		var (
+			subject ManageOfferBuilder
+			mut     interface{}
+
+			rate = Rate{
+				Selling: CreditAsset("EUR", "GAWSI2JO2CF36Z43UGMUJCDQ2IMR5B3P5TMS7XM7NUTU3JHG3YJUDQXA"),
+				Buying:  NativeAsset(),
+				Price:   Price("41.265"),
+			}
+		)
+
+		JustBeforeEach(func() {
+			subject = ManageOfferBuilder{}
+			subject.Mutate(mut)
+		})
+
+		Describe("CreatePassiveOffer", func() {
+			Context("creates offer properly", func() {
+				It("sets values properly", func() {
+					builder := CreatePassiveOffer(rate, "20")
+
+					Expect(builder.PO.Amount).To(Equal(xdr.Int64(200000000)))
+
+					Expect(builder.PO.Selling.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
+					Expect(builder.PO.Selling.AlphaNum4.AssetCode).To(Equal([4]byte{'E', 'U', 'R', 0}))
+					aid, _ := stellarbase.AddressToAccountId(rate.Selling.Issuer)
+					Expect(builder.PO.Selling.AlphaNum4.Issuer.MustEd25519()).To(Equal(aid.MustEd25519()))
+					Expect(builder.PO.Selling.AlphaNum12).To(BeNil())
+
+					Expect(builder.PO.Buying.Type).To(Equal(xdr.AssetTypeAssetTypeNative))
+					Expect(builder.PO.Buying.AlphaNum4).To(BeNil())
+					Expect(builder.PO.Buying.AlphaNum12).To(BeNil())
+
+					Expect(builder.PO.Price.N).To(Equal(xdr.Int32(8253)))
+					Expect(builder.PO.Price.D).To(Equal(xdr.Int32(200)))
+				})
+			})
+		})
+	})
+})

--- a/vendor/src/github.com/stellar/go-stellar-base/build/payment.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/payment.go
@@ -140,32 +140,17 @@ func (m PayWithPath) MutatePayment(o interface{}) (err error) {
 	var xdrAsset xdr.Asset
 
 	for _, asset := range m.Path {
-		switch {
-		case asset.Native:
-			xdrAsset, err = xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
-			path = append(path, xdrAsset)
-		case !asset.Native:
-			xdrAsset, err = createAlphaNumAsset(asset.Code, asset.Issuer)
-			path = append(path, xdrAsset)
-		default:
-			err = errors.New("Unknown Asset type")
-		}
-
+		xdrAsset, err = asset.ToXdrObject()
 		if err != nil {
 			return err
 		}
+
+		path = append(path, xdrAsset)
 	}
 
 	pathPaymentOp.Path = path
 
 	// Asset
-	switch {
-	case m.Asset.Native:
-		pathPaymentOp.SendAsset, err = xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
-	case !m.Asset.Native:
-		pathPaymentOp.SendAsset, err = createAlphaNumAsset(m.Asset.Code, m.Asset.Issuer)
-	default:
-		err = errors.New("Unknown Asset type")
-	}
+	pathPaymentOp.SendAsset, err = m.Asset.ToXdrObject()
 	return
 }

--- a/vendor/src/github.com/stellar/go-stellar-base/build/set_options.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/set_options.go
@@ -1,0 +1,250 @@
+package build
+
+import (
+	"errors"
+
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// SetOptions groups the creation of a new SetOptions with a call to Mutate.
+func SetOptions(muts ...interface{}) (result SetOptionsBuilder) {
+	result.Mutate(muts...)
+	return
+}
+
+// SetOptionsMutator is a interface that wraps the
+// MutateSetOptions operation.  types may implement this interface to
+// specify how they modify an xdr.SetOptionsOp object
+type SetOptionsMutator interface {
+	MutateSetOptions(*xdr.SetOptionsOp) error
+}
+
+// SetOptionsBuilder represents a transaction that is being built.
+type SetOptionsBuilder struct {
+	O   xdr.Operation
+	SO  xdr.SetOptionsOp
+	Err error
+}
+
+// Mutate applies the provided mutators to this builder's payment or operation.
+func (b *SetOptionsBuilder) Mutate(muts ...interface{}) {
+	for _, m := range muts {
+		var err error
+		switch mut := m.(type) {
+		case SetOptionsMutator:
+			err = mut.MutateSetOptions(&b.SO)
+		case OperationMutator:
+			err = mut.MutateOperation(&b.O)
+		default:
+			err = errors.New("Mutator type not allowed")
+		}
+
+		if err != nil {
+			b.Err = err
+			return
+		}
+	}
+}
+
+// MutateSetOptions for HomeDomain sets the SetOptionsOp's HomeDomain field
+func (m HomeDomain) MutateSetOptions(o *xdr.SetOptionsOp) (err error) {
+	if len(m) > 32 {
+		return errors.New("HomeDomain is too long")
+	}
+
+	value := xdr.String32(m)
+	o.HomeDomain = &value
+	return
+}
+
+// MutateTransaction for HomeDomain allows creating an operation using a single mutator
+func (m HomeDomain) MutateTransaction(t *TransactionBuilder) error {
+	return mutateTransactionBuilder(t, m)
+}
+
+// MutateSetOptions for InflationDest sets the SetOptionsOp's InflationDest field
+func (m InflationDest) MutateSetOptions(o *xdr.SetOptionsOp) (err error) {
+	o.InflationDest = &xdr.AccountId{}
+	err = setAccountId(string(m), o.InflationDest)
+	return
+}
+
+// MutateTransaction for InflationDest allows creating an operation using a single mutator
+func (m InflationDest) MutateTransaction(t *TransactionBuilder) error {
+	return mutateTransactionBuilder(t, m)
+}
+
+// MutateSetOptions for MasterWeight sets the SetOptionsOp's MasterWeight field
+func (m MasterWeight) MutateSetOptions(o *xdr.SetOptionsOp) (err error) {
+	val := xdr.Uint32(m)
+	o.MasterWeight = &val
+	return
+}
+
+// MutateTransaction for MasterWeight allows creating an operation using a single mutator
+func (m MasterWeight) MutateTransaction(t *TransactionBuilder) error {
+	return mutateTransactionBuilder(t, m)
+}
+
+// AddSigner creates Signer mutator that sets account's signer
+func AddSigner(publicKey string, weight uint32) Signer {
+	return Signer{publicKey, weight}
+}
+
+// RemoveSigner creates Signer mutator that removes account's signer
+func RemoveSigner(publicKey string) Signer {
+	return Signer{publicKey, 0}
+}
+
+// MutateSetOptions for Signer sets the SetOptionsOp's signer field
+func (m Signer) MutateSetOptions(o *xdr.SetOptionsOp) (err error) {
+	var signer xdr.Signer
+	signer.Weight = xdr.Uint32(m.Weight)
+	err = setAccountId(m.PublicKey, &signer.PubKey)
+	o.Signer = &signer
+	return
+}
+
+// MutateTransaction for Signer allows creating an operation using a single mutator
+func (m Signer) MutateTransaction(t *TransactionBuilder) error {
+	return mutateTransactionBuilder(t, m)
+}
+
+// SetThresholds creates Thresholds mutator
+func SetThresholds(low, medium, high uint32) Thresholds {
+	return Thresholds{
+		Low:    &low,
+		Medium: &medium,
+		High:   &high,
+	}
+}
+
+// SetLowThreshold creates Thresholds mutator that sets account's low threshold
+func SetLowThreshold(value uint32) Thresholds {
+	return Thresholds{Low: &value}
+}
+
+// SetMediumThreshold creates Thresholds mutator that sets account's medium threshold
+func SetMediumThreshold(value uint32) Thresholds {
+	return Thresholds{Medium: &value}
+}
+
+// SetHighThreshold creates Thresholds mutator that sets account's high threshold
+func SetHighThreshold(value uint32) Thresholds {
+	return Thresholds{High: &value}
+}
+
+// MutateSetOptions for Thresholds sets the SetOptionsOp's thresholds fields
+func (m Thresholds) MutateSetOptions(o *xdr.SetOptionsOp) (err error) {
+	if m.Low != nil {
+		val := xdr.Uint32(*m.Low)
+		o.LowThreshold = &val
+	}
+
+	if m.Medium != nil {
+		val := xdr.Uint32(*m.Medium)
+		o.MedThreshold = &val
+	}
+
+	if m.High != nil {
+		val := xdr.Uint32(*m.High)
+		o.HighThreshold = &val
+	}
+
+	return
+}
+
+// MutateTransaction for Thresholds allows creating an operation using a single mutator
+func (m Thresholds) MutateTransaction(t *TransactionBuilder) error {
+	return mutateTransactionBuilder(t, m)
+}
+
+// SetAuthRequired sets AuthRequiredFlag on SetOptions operation
+func SetAuthRequired() SetFlag {
+	return SetFlag(xdr.AccountFlagsAuthRequiredFlag)
+}
+
+// SetAuthRevocable sets AuthRevocableFlag on SetOptions operation
+func SetAuthRevocable() SetFlag {
+	return SetFlag(xdr.AccountFlagsAuthRevocableFlag)
+}
+
+// SetAuthImmutable sets AuthImmutableFlag on SetOptions operation
+func SetAuthImmutable() SetFlag {
+	return SetFlag(xdr.AccountFlagsAuthImmutableFlag)
+}
+
+// MutateSetOptions for SetFlag sets the SetOptionsOp's SetFlags field
+func (m SetFlag) MutateSetOptions(o *xdr.SetOptionsOp) (err error) {
+	if !isFlagValid(xdr.AccountFlags(m)) {
+		return errors.New("Unknown flag in SetFlag mutator")
+	}
+
+	var val xdr.Uint32
+	if o.SetFlags == nil {
+		val = xdr.Uint32(m)
+	} else {
+		val = xdr.Uint32(m) | *o.SetFlags
+	}
+	o.SetFlags = &val
+	return
+}
+
+// MutateTransaction for SetFlag allows creating an operation using a single mutator
+func (m SetFlag) MutateTransaction(t *TransactionBuilder) error {
+	return mutateTransactionBuilder(t, m)
+}
+
+// ClearAuthRequired clears AuthRequiredFlag on SetOptions operation
+func ClearAuthRequired() ClearFlag {
+	return ClearFlag(xdr.AccountFlagsAuthRequiredFlag)
+}
+
+// ClearAuthRevocable clears AuthRevocableFlag on SetOptions operation
+func ClearAuthRevocable() ClearFlag {
+	return ClearFlag(xdr.AccountFlagsAuthRevocableFlag)
+}
+
+// ClearAuthImmutable clears AuthImmutableFlag on SetOptions operation
+func ClearAuthImmutable() ClearFlag {
+	return ClearFlag(xdr.AccountFlagsAuthImmutableFlag)
+}
+
+// MutateSetOptions for ClearFlag sets the SetOptionsOp's ClearFlags field
+func (m ClearFlag) MutateSetOptions(o *xdr.SetOptionsOp) (err error) {
+	if !isFlagValid(xdr.AccountFlags(m)) {
+		return errors.New("Unknown flag in SetFlag mutator")
+	}
+
+	var val xdr.Uint32
+	if o.ClearFlags == nil {
+		val = xdr.Uint32(m)
+	} else {
+		val = xdr.Uint32(m) | *o.ClearFlags
+	}
+	o.ClearFlags = &val
+	return
+}
+
+// MutateTransaction for ClearFlag allows creating an operation using a single mutator
+func (m ClearFlag) MutateTransaction(t *TransactionBuilder) error {
+	return mutateTransactionBuilder(t, m)
+}
+
+func isFlagValid(flag xdr.AccountFlags) bool {
+	if flag != xdr.AccountFlagsAuthRequiredFlag &&
+		flag != xdr.AccountFlagsAuthRevocableFlag &&
+		flag != xdr.AccountFlagsAuthImmutableFlag {
+		return false
+	}
+	return true
+}
+
+func mutateTransactionBuilder(t *TransactionBuilder, m SetOptionsMutator) error {
+	builder := SetOptions(m)
+	if builder.Err != nil {
+		return builder.Err
+	}
+	t.Mutate(builder)
+	return nil
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/build/set_options_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/set_options_test.go
@@ -1,0 +1,177 @@
+package build
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stellar/go-stellar-base"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+var _ = Describe("SetOptionsBuilder Mutators", func() {
+
+	var (
+		subject SetOptionsBuilder
+		mut     interface{}
+
+		address = "GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ"
+		bad     = "foo"
+	)
+
+	JustBeforeEach(func() {
+		subject = SetOptionsBuilder{}
+		subject.Mutate(mut)
+	})
+
+	Describe("InflationDest", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = InflationDest(address) })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.SO.InflationDest.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = InflationDest(bad) })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("Signer", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = Signer{address, 5} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the values", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.SO.Signer.PubKey.MustEd25519()).To(Equal(aid.MustEd25519()))
+				Expect(subject.SO.Signer.Weight).To(Equal(xdr.Uint32(5)))
+			})
+		})
+
+		Context("using an invalid PubKey", func() {
+			BeforeEach(func() { mut = Signer{bad, 5} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("HomeDomain", func() {
+		Context("using a valid value", func() {
+			BeforeEach(func() { mut = HomeDomain("stellar.org") })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the HomeDomain to correct value", func() {
+				Expect(*subject.SO.HomeDomain).To(Equal(xdr.String32("stellar.org")))
+			})
+		})
+
+		Context("value too long", func() {
+			BeforeEach(func() { mut = HomeDomain("123456789012345678901234567890123") })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("SetFlag", func() {
+		Context("using a valid account flag", func() {
+			BeforeEach(func() { mut = SetFlag(1) })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the flag to the correct value", func() {
+				Expect(*subject.SO.SetFlags).To(Equal(xdr.Uint32(1)))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = SetFlag(3) })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("ClearFlag", func() {
+		Context("using a valid account flag", func() {
+			BeforeEach(func() { mut = ClearFlag(1) })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the flag to the correct value", func() {
+				Expect(*subject.SO.ClearFlags).To(Equal(xdr.Uint32(1)))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = ClearFlag(3) })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("MasterWeight", func() {
+		Context("using a valid weight", func() {
+			BeforeEach(func() { mut = MasterWeight(1) })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the weight to the correct value", func() {
+				Expect(*subject.SO.MasterWeight).To(Equal(xdr.Uint32(1)))
+			})
+		})
+	})
+
+	Describe("Thresholds", func() {
+		Context("using a valid weight", func() {
+			BeforeEach(func() {
+				low := uint32(1)
+				med := uint32(2)
+				high := uint32(3)
+				mut = Thresholds{&low, &med, &high}
+			})
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the thresholds to the correct value", func() {
+				Expect(*subject.SO.LowThreshold).To(Equal(xdr.Uint32(1)))
+				Expect(*subject.SO.MedThreshold).To(Equal(xdr.Uint32(2)))
+				Expect(*subject.SO.HighThreshold).To(Equal(xdr.Uint32(3)))
+			})
+		})
+	})
+
+	Describe("SourceAccount", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = SourceAccount{address} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.O.SourceAccount.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = SourceAccount{bad} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+})

--- a/vendor/src/github.com/stellar/go-stellar-base/build/transaction.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/transaction.go
@@ -99,6 +99,18 @@ func (b *TransactionBuilder) Sign(signers ...string) (result TransactionEnvelope
 //
 // ------------------------------------------------------------
 
+// MutateTransaction for AccountMergeBuilder causes the underylying Destination
+// to be added to the operation list for the provided transaction
+func (m AccountMergeBuilder) MutateTransaction(o *TransactionBuilder) error {
+	if m.Err != nil {
+		return m.Err
+	}
+
+	m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeAccountMerge, m.Destination)
+	o.TX.Operations = append(o.TX.Operations, m.O)
+	return m.Err
+}
+
 // MutateTransaction for AllowTrustBuilder causes the underylying AllowTrustOp
 // to be added to the operation list for the provided transaction
 func (m AllowTrustBuilder) MutateTransaction(o *TransactionBuilder) error {
@@ -150,6 +162,19 @@ func (m Defaults) MutateTransaction(o *TransactionBuilder) error {
 	return nil
 }
 
+// MutateTransaction for InflationBuilder causes the underylying
+// InflationOp to be added to the operation list for the provided
+// transaction
+func (m InflationBuilder) MutateTransaction(o *TransactionBuilder) error {
+	if m.Err != nil {
+		return m.Err
+	}
+
+	m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeInflation, nil)
+	o.TX.Operations = append(o.TX.Operations, m.O)
+	return m.Err
+}
+
 // MutateTransaction for ManageDataBuilder causes the underylying
 // ManageData to be added to the operation list for the provided
 // transaction
@@ -160,6 +185,24 @@ func (m ManageDataBuilder) MutateTransaction(o *TransactionBuilder) error {
 
 	m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeManageData, m.MD)
 	o.TX.Operations = append(o.TX.Operations, m.O)
+	return m.Err
+}
+
+// MutateTransaction for ManageOfferBuilder causes the underylying
+// ManageData to be added to the operation list for the provided
+// transaction
+func (m ManageOfferBuilder) MutateTransaction(o *TransactionBuilder) error {
+	if m.Err != nil {
+		return m.Err
+	}
+
+	if m.PassiveOffer {
+		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeCreatePassiveOffer, m.PO)
+		o.TX.Operations = append(o.TX.Operations, m.O)
+	} else {
+		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeManageOffer, m.MO)
+		o.TX.Operations = append(o.TX.Operations, m.O)
+	}
 	return m.Err
 }
 
@@ -213,6 +256,19 @@ func (m PaymentBuilder) MutateTransaction(o *TransactionBuilder) error {
 	}
 
 	m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePayment, m.P)
+	o.TX.Operations = append(o.TX.Operations, m.O)
+	return m.Err
+}
+
+// MutateTransaction for SetOptionsBuilder causes the underylying
+// SetOptionsOp to be added to the operation list for the provided
+// transaction
+func (m SetOptionsBuilder) MutateTransaction(o *TransactionBuilder) error {
+	if m.Err != nil {
+		return m.Err
+	}
+
+	m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeSetOptions, m.SO)
 	o.TX.Operations = append(o.TX.Operations, m.O)
 	return m.Err
 }

--- a/vendor/src/github.com/stellar/go-stellar-base/build/transaction.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/transaction.go
@@ -111,6 +111,19 @@ func (m AllowTrustBuilder) MutateTransaction(o *TransactionBuilder) error {
 	return m.Err
 }
 
+// MutateTransaction for ChangeTrustBuilder causes the underylying
+// CreateAccountOp to be added to the operation list for the provided
+// transaction
+func (m ChangeTrustBuilder) MutateTransaction(o *TransactionBuilder) error {
+	if m.Err != nil {
+		return m.Err
+	}
+
+	m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypeChangeTrust, m.CT)
+	o.TX.Operations = append(o.TX.Operations, m.O)
+	return m.Err
+}
+
 // MutateTransaction for CreateAccountBuilder causes the underylying
 // CreateAccountOp to be added to the operation list for the provided
 // transaction
@@ -197,11 +210,11 @@ func (m PaymentBuilder) MutateTransaction(o *TransactionBuilder) error {
 		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePathPayment, m.PP)
 		o.TX.Operations = append(o.TX.Operations, m.O)
 		return m.Err
-	} else {
-		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePayment, m.P)
-		o.TX.Operations = append(o.TX.Operations, m.O)
-		return m.Err
 	}
+
+	m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePayment, m.P)
+	o.TX.Operations = append(o.TX.Operations, m.O)
+	return m.Err
 }
 
 // MutateTransaction for Sequence sets the SeqNum on the transaction.

--- a/vendor/src/github.com/stellar/go-stellar-base/build/util.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/build/util.go
@@ -13,6 +13,10 @@ func setAccountId(addressOrSeed string, aid *xdr.AccountId) error {
 		return err
 	}
 
+	if aid == nil {
+		return errors.New("aid is nil in setAccountId")
+	}
+
 	return aid.SetAddress(kp.Address())
 }
 

--- a/vendor/src/github.com/stellar/go-stellar-base/horizon/main.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/horizon/main.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
-
-	res "github.com/stellar/go-stellar-base/horizon/response"
 )
 
 // DefaultTestNetClient is a default client to connect to test network
@@ -18,7 +16,7 @@ var DefaultPublicNetClient = &Client{URL: "https://horizon.stellar.org"}
 // HorizonError struct contains the problem returned by Horizon
 type Error struct {
 	Response *http.Response
-	Problem  res.Problem
+	Problem  Problem
 }
 
 func (herror *Error) Error() string {
@@ -41,7 +39,7 @@ type Client struct {
 }
 
 // LoadAccount loads the account state from horizon. err can be either error object or horizon.Error object.
-func (c *Client) LoadAccount(accountId string) (account res.Account, err error) {
+func (c *Client) LoadAccount(accountId string) (account Account, err error) {
 	c.initHttpClient()
 	resp, err := c.Client.Get(c.URL + "/accounts/" + accountId)
 	if err != nil {
@@ -53,7 +51,7 @@ func (c *Client) LoadAccount(accountId string) (account res.Account, err error) 
 }
 
 // SubmitTransaction submits a transaction to the network. err can be either error object or horizon.Error object.
-func (c *Client) SubmitTransaction(transactionEnvelopeXdr string) (response res.TransactionSuccess, err error) {
+func (c *Client) SubmitTransaction(transactionEnvelopeXdr string) (response TransactionSuccess, err error) {
 	v := url.Values{}
 	v.Set("tx", transactionEnvelopeXdr)
 

--- a/vendor/src/github.com/stellar/go-stellar-base/horizon/main_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/horizon/main_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Horizon", func() {
 			Expect(err).To(BeNil())
 			Expect(account.ID).To(Equal("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"))
 			Expect(account.PT).To(Equal("1"))
+			Expect(account.GetNativeBalance()).To(Equal("948522307.6146000"))
 		})
 
 		It("failure response", func() {

--- a/vendor/src/github.com/stellar/go-stellar-base/horizon/response/doc.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/horizon/response/doc.go
@@ -1,2 +1,0 @@
-// Package response contains response structs from horizon
-package response

--- a/vendor/src/github.com/stellar/go-stellar-base/horizon/responses.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/horizon/responses.go
@@ -1,4 +1,5 @@
-package response
+// This file contains response structs from horizon
+package horizon
 
 type Problem struct {
 	Type     string                 `json:"type"`
@@ -28,6 +29,16 @@ type Account struct {
 	Flags                AccountFlags      `json:"flags"`
 	Balances             []Balance         `json:"balances"`
 	Signers              []Signer          `json:"signers"`
+}
+
+func (a Account) GetNativeBalance() string {
+	for _, balance := range a.Balances {
+		if balance.Asset.Type == "native" {
+			return balance.Balance
+		}
+	}
+
+	return "0"
 }
 
 type AccountFlags struct {

--- a/vendor/src/github.com/stellar/go-stellar-base/price/main.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/price/main.go
@@ -1,0 +1,85 @@
+package price
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// Parse  calculates and returns the best rational approximation of the given real number price.
+func Parse(v string) (xdr.Price, error) {
+	return continuedFraction(v)
+}
+
+// continuedFraction calculates and returns the best rational approximation of the given real number.
+func continuedFraction(price string) (xdrPrice xdr.Price, err error) {
+	number := &big.Rat{}
+	maxInt32 := &big.Rat{}
+	zero := &big.Rat{}
+	one := &big.Rat{}
+
+	_, ok := number.SetString(price)
+	if !ok {
+		return xdrPrice, fmt.Errorf("cannot parse price: %s", price)
+	}
+
+	maxInt32.SetInt64(int64(math.MaxInt32))
+	zero.SetInt64(int64(0))
+	one.SetInt64(int64(1))
+
+	fractions := [][2]*big.Rat{
+		{zero, one},
+		{one, zero},
+	}
+
+	i := 2
+	for {
+		if number.Cmp(maxInt32) == 1 {
+			break
+		}
+
+		f := &big.Rat{}
+		h := &big.Rat{}
+		k := &big.Rat{}
+
+		a := floor(number)
+		f.Sub(number, a)
+		h.Mul(a, fractions[i-1][0])
+		h.Add(h, fractions[i-2][0])
+		k.Mul(a, fractions[i-1][1])
+		k.Add(k, fractions[i-2][1])
+
+		if h.Cmp(maxInt32) == 1 || k.Cmp(maxInt32) == 1 {
+			break
+		}
+
+		fractions = append(fractions, [2]*big.Rat{h, k})
+		if f.Cmp(zero) == 0 {
+			break
+		}
+		number.Quo(one, f)
+		i++
+	}
+
+	n, d := fractions[len(fractions)-1][0], fractions[len(fractions)-1][1]
+
+	if n.Cmp(zero) == 0 || d.Cmp(zero) == 0 {
+		return xdrPrice, errors.New("Couldn't find approximation")
+	}
+
+	return xdr.Price{
+		N: xdr.Int32(n.Num().Int64()),
+		D: xdr.Int32(d.Num().Int64()),
+	}, nil
+}
+
+func floor(n *big.Rat) *big.Rat {
+	f := &big.Rat{}
+	z := new(big.Int)
+	z.Div(n.Num(), n.Denom())
+	f.SetInt(z)
+	return f
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/price/main_test.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/price/main_test.go
@@ -1,0 +1,56 @@
+package price_test
+
+import (
+	"github.com/stellar/go-stellar-base/price"
+	"github.com/stellar/go-stellar-base/xdr"
+	"testing"
+)
+
+var Tests = []struct {
+	S string
+	P xdr.Price
+}{
+	{"0.1", xdr.Price{1, 10}},
+	{"0.01", xdr.Price{1, 100}},
+	{"0.001", xdr.Price{1, 1000}},
+	{"543.017930", xdr.Price{54301793, 100000}},
+	{"319.69983", xdr.Price{31969983, 100000}},
+	{"0.93", xdr.Price{93, 100}},
+	{"0.5", xdr.Price{1, 2}},
+	{"1.730", xdr.Price{173, 100}},
+	{"0.85334384", xdr.Price{5333399, 6250000}},
+	{"5.5", xdr.Price{11, 2}},
+	{"2.72783", xdr.Price{272783, 100000}},
+	{"638082.0", xdr.Price{638082, 1}},
+	{"2.93850088", xdr.Price{36731261, 12500000}},
+	{"58.04", xdr.Price{1451, 25}},
+	{"41.265", xdr.Price{8253, 200}},
+	{"5.1476", xdr.Price{12869, 2500}},
+	{"95.14", xdr.Price{4757, 50}},
+	{"0.74580", xdr.Price{3729, 5000}},
+	{"4119.0", xdr.Price{4119, 1}},
+}
+
+func TestParse(t *testing.T) {
+	for _, v := range Tests {
+		o, err := price.Parse(v.S)
+		if err != nil {
+			t.Errorf("Couldn't parse %s: %v+", v.S, err)
+			continue
+		}
+
+		if o.N != v.P.N || o.D != v.P.D {
+			t.Errorf("%s parsed to %d, not %d", v.S, o, v.P)
+		}
+	}
+
+	_, err := price.Parse("0.0000000003")
+	if err == nil {
+		t.Error("Expected error")
+	}
+
+	_, err = price.Parse("2147483649")
+	if err == nil {
+		t.Error("Expected error")
+	}
+}

--- a/vendor/src/github.com/stellar/go-stellar-base/xdr/xdr_generated.go
+++ b/vendor/src/github.com/stellar/go-stellar-base/xdr/xdr_generated.go
@@ -306,11 +306,21 @@ type Thresholds [4]byte
 //
 type String32 string
 
+// XDRMaxSize implements the Sized interface for String32
+func (e String32) XDRMaxSize() int {
+	return 32
+}
+
 // String64 is an XDR Typedef defines as:
 //
 //   typedef string string64<64>;
 //
 type String64 string
+
+// XDRMaxSize implements the Sized interface for String64
+func (e String64) XDRMaxSize() int {
+	return 64
+}
 
 // SequenceNumber is an XDR Typedef defines as:
 //
@@ -733,7 +743,7 @@ type AccountEntry struct {
 	Flags         Uint32
 	HomeDomain    String32
 	Thresholds    Thresholds
-	Signers       []Signer
+	Signers       []Signer `xdrmaxsize:"20"`
 	Ext           AccountEntryExt
 }
 
@@ -1416,7 +1426,7 @@ type PathPaymentOp struct {
 	Destination AccountId
 	DestAsset   Asset
 	DestAmount  Int64
-	Path        []Asset
+	Path        []Asset `xdrmaxsize:"5"`
 }
 
 // ManageOfferOp is an XDR Struct defines as:
@@ -2420,7 +2430,7 @@ type Transaction struct {
 	SeqNum        SequenceNumber
 	TimeBounds    *TimeBounds
 	Memo          Memo
-	Operations    []Operation
+	Operations    []Operation `xdrmaxsize:"100"`
 	Ext           TransactionExt
 }
 
@@ -2434,7 +2444,7 @@ type Transaction struct {
 //
 type TransactionEnvelope struct {
 	Tx         Transaction
-	Signatures []DecoratedSignature
+	Signatures []DecoratedSignature `xdrmaxsize:"20"`
 }
 
 // ClaimOfferAtom is an XDR Struct defines as:
@@ -4625,7 +4635,7 @@ func NewStellarValueExt(v int32, value interface{}) (result StellarValueExt, err
 type StellarValue struct {
 	TxSetHash Hash
 	CloseTime Uint64
-	Upgrades  []UpgradeType
+	Upgrades  []UpgradeType `xdrmaxsize:"6"`
 	Ext       StellarValueExt
 }
 
@@ -5308,7 +5318,7 @@ const MaxTxPerLedger = 5000
 //
 type TransactionSet struct {
 	PreviousLedgerHash Hash
-	Txs                []TransactionEnvelope
+	Txs                []TransactionEnvelope `xdrmaxsize:"5000"`
 }
 
 // TransactionResultPair is an XDR Struct defines as:
@@ -5332,7 +5342,7 @@ type TransactionResultPair struct {
 //    };
 //
 type TransactionResultSet struct {
-	Results []TransactionResultPair
+	Results []TransactionResultPair `xdrmaxsize:"5000"`
 }
 
 // TransactionHistoryEntryExt is an XDR NestedUnion defines as:
@@ -5967,7 +5977,7 @@ func (e ErrorCode) String() string {
 //
 type Error struct {
 	Code ErrorCode
-	Msg  string
+	Msg  string `xdrmaxsize:"100"`
 }
 
 // AuthCert is an XDR Struct defines as:
@@ -6005,7 +6015,7 @@ type Hello struct {
 	OverlayVersion    Uint32
 	OverlayMinVersion Uint32
 	NetworkId         Hash
-	VersionStr        string
+	VersionStr        string `xdrmaxsize:"100"`
 	ListeningPort     int32
 	PeerId            NodeId
 	Cert              AuthCert


### PR DESCRIPTION
Implements `/builder` endpoint that builds a transaction and returns `TransactionEnvelope` XDR. More operations will be added when implemented in go-stellar-base (https://github.com/stellar/go-stellar-base/issues/28).

In https://github.com/stellar/bridge-server/issues/13 @nullstyle suggested:
> If I were designing the server I would try to mirror the response output of horizon for the input to this server. Specifying an operation in this service should have the same general shape as the operation resource in horizon.

I strongly believe that when constructing transactions using `/builder` endpoint users should understand how low level transaction look like. I think that many of developers (especially new to Stellar) will check built transaction using XDR Viewer and use [List of Operations](https://www.stellar.org/developers/learn/concepts/list-of-operations.html) to learn about operations. Different names will cause confusion.

When it comes to asset representation, in this issue: https://github.com/stellar/horizon/issues/232 our community member suggests to switch to JSON object when presenting assets. This form not only makes responses easier to parse but requests easier to build. I decided to go with this solution. For example, here's how `change_trust` operation body looks like:
```json
{
  "type": "change_trust",
  "body": {
    "source": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT",
    "asset": {
      "code": "USD",
      "issuer": "GBDCOZD7CHY26KS6ABEZPIJAMS2G7GP3YSTJ6DIRIQ6YUU77ZAPI2LVT"
    }
  }
}
```
To make user's life easier I also don't require them to pass asset type. Bridge server will create valid asset based on the code length.