### PR TITLE
Bridge and Compliance configuration examples had overlapping ports

### DIFF
--- a/bridge_example.cfg
+++ b/bridge_example.cfg
@@ -1,6 +1,6 @@
 # Bridge server bridge.cfg example
 
-port = 8001
+port = 8006
 horizon = "https://horizon-testnet.stellar.org"
 network_passphrase = "Test SDF Network ; September 2015"
 api_key = ""


### PR DESCRIPTION
If someone was copy-pasting their way through initial setup, the ports collide between _bridge_example.cfg_ and _compliance_example.cfg_