### PR TITLE
print bridge server version

### DIFF
--- a/src/github.com/stellar/gateway/bridge/app.go
+++ b/src/github.com/stellar/gateway/bridge/app.go
@@ -33,7 +33,7 @@ type App struct {
 }
 
 // NewApp constructs an new App instance from the provided config.
-func NewApp(config config.Config, migrateFlag bool) (app *App, err error) {
+func NewApp(config config.Config, migrateFlag bool, versionFlag bool, version string) (app *App, err error) {
 	var g inject.Graph
 
 	var driver db.Driver
@@ -76,6 +76,12 @@ func NewApp(config config.Config, migrateFlag bool) (app *App, err error) {
 		}
 
 		log.Info("Applied migrations: ", migrationsApplied)
+		os.Exit(0)
+		return
+	}
+
+	if versionFlag {
+		fmt.Printf("Bridge Server Version: %s \n", version)
 		os.Exit(0)
 		return
 	}

--- a/src/github.com/stellar/gateway/cmd/bridge/main.go
+++ b/src/github.com/stellar/gateway/cmd/bridge/main.go
@@ -14,6 +14,8 @@ var app *bridge.App
 var rootCmd *cobra.Command
 var migrateFlag bool
 var configFile string
+var versionFlag bool
+var version = "N/A"
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
@@ -30,6 +32,7 @@ func init() {
 
 	rootCmd.Flags().BoolVarP(&migrateFlag, "migrate-db", "", false, "migrate DB to the newest schema version")
 	rootCmd.Flags().StringVarP(&configFile, "config", "c", "bridge.cfg", "path to config file")
+	rootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "displays bridge server version")
 }
 
 func run(cmd *cobra.Command, args []string) {
@@ -53,7 +56,7 @@ func run(cmd *cobra.Command, args []string) {
 		log.SetFormatter(&log.JSONFormatter{})
 	}
 
-	app, err = bridge.NewApp(config, migrateFlag)
+	app, err = bridge.NewApp(config, migrateFlag, versionFlag, version)
 
 	if err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
prints bridge server version with  `./bridge -v` or `.bridge --version`
resolves issue #64 

The binary must have been built with the flag `-ldflags "-X main.version=[VERSION_NO]"` for this to work
`