### PR TITLE
Admin GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /bin
 /dist
 /config.toml
+/gui/.tmp
+/gui/yarn.lock
+/gui/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /gui/.tmp
 /gui/yarn.lock
 /gui/node_modules
+/gui/dist

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ gb build
 
 After a successful build, you should find `bin/bridge` in the project directory.
 
+### GUI
+
+To build user interface for the bridge server go to `gui` folder and run:
+
+```
+gulp build
+```
+
+For development run:
+
+```
+gulp develop
+```
+
 ## Running tests
 
 ```

--- a/gui/gulpfile.babel.js
+++ b/gui/gulpfile.babel.js
@@ -1,0 +1,116 @@
+'use strict';
+
+var _       = require('lodash');
+var bs      = require('browser-sync').create();
+var gulp    = require('gulp');
+var path    = require('path');
+var webpack = require("webpack");
+
+gulp.task('default', ['develop']);
+
+var webpackOptions = {
+  entry: {
+    app: "./src/app.js",
+    vendor: ["react", "react-dom", "muicss", "stellar-sdk", "axios", "d3", "fbemitter"]
+  },
+  devtool: "source-map",
+  resolve: {
+    root: [
+      path.resolve('src'),
+      path.resolve('common')
+    ],
+    modulesDirectories: ["node_modules"]
+  },
+  module: {
+    loaders: [
+      {test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader', query: {presets: ['es2015', 'react']}},
+      {test: /\.json$/, loader: 'json'},
+      {test: /\.html$/, loader: 'file?name=[name].html'},
+    ]
+  },
+  plugins: [
+    new webpack.IgnorePlugin(/ed25519/)
+  ]
+};
+
+gulp.task('develop', function(done) {
+  var options = merge(webpackOptions, {
+    output: {
+      filename: "[name].js",
+      path: './.tmp/admin'
+    },
+    plugins: [
+      new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.js")
+    ]
+  });
+
+  var watchOptions = {
+    aggregateTimeout: 300
+  };
+
+  var bsInitialized = false;
+
+  var compiler = webpack(options);
+  compiler.purgeInputFileSystem();
+  compiler.watch(watchOptions, function(error, stats) {
+    if (!bsInitialized) {
+      gulp.watch(".tmp/**/*").on("change", bs.reload);
+      bs.init({
+        port: 3000,
+        online: false,
+        notify: false,
+        server: "./.tmp",
+        startPath: '/admin/index.html',
+        socket: {
+          // Golang httputil.ReverseProxy removes trailing slash from request before passing
+          // it to destination folder. This made the socket.io used by browser-sync fail.
+          // Make sure socket.io client connects to the destination server (not use proxy).
+          domain: 'localhost:3000'
+        }
+      });
+      bsInitialized = true;
+    }
+    console.log(stats.toString({
+      hash: false,
+      version: false,
+      timings: true,
+      chunks: false,
+      colors: true
+    }));
+  });
+});
+
+gulp.task('build', function(done) {
+  var options = merge(webpackOptions, {
+    bail: true,
+    output: {
+      // TODO chunkhash
+      filename: "[name].js",//"[name]-[chunkhash].js",
+      path: './dist'
+    },
+    plugins: [
+      new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.js"),
+      new webpack.optimize.DedupePlugin(),
+      new webpack.optimize.OccurenceOrderPlugin(),
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify('production'),
+        }
+      }),
+      new webpack.optimize.UglifyJsPlugin()
+    ]
+  });
+
+  var compiler = webpack(options);
+  compiler.purgeInputFileSystem();
+  compiler.run(done);
+});
+
+
+function merge(object1, object2) {
+  return _.mergeWith(object1, object2, function(a, b) {
+    if (_.isArray(a)) {
+      return a.concat(b);
+    }
+  });
+}

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "bridge-server-admin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "Stellar.org",
+  "dependencies": {
+    "axios": "^0.15.3",
+    "babel-core": "^6.23.0",
+    "babel-loader": "^6.3.2",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.23.0",
+    "babel-register": "^6.24.0",
+    "bignumber.js": "^3.0.1",
+    "browser-sync": "^2.18.2",
+    "fbemitter": "^2.1.1",
+    "file-loader": "^0.9.0",
+    "gulp": "^3.9.1",
+    "lodash": "^4.17.2",
+    "moment": "^2.17.1",
+    "muicss": "^0.9.24",
+    "react": "^15.4.1",
+    "react-d3-components": "^0.6.5",
+    "react-dom": "^15.4.1",
+    "react-router-dom": "^4.2.2",
+    "stellar-sdk": "^0.6.2",
+    "webpack": "^1.13.3"
+  }
+}

--- a/gui/src/app.js
+++ b/gui/src/app.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './components/App.js';
+
+require('./index.html');
+
+ReactDOM.render(
+  <App></App>,
+  document.getElementById('app')
+);

--- a/gui/src/components/App.js
+++ b/gui/src/components/App.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import {HashRouter as Router, Route, Link} from 'react-router-dom';
+import AppBar from './AppBar';
+import Navigation from './Navigation';
+import ReceivedTransactions from './ReceivedTransactions';
+import ReceivedTransactionDetails from './ReceivedTransactionDetails';
+import SentTransactions from './SentTransactions';
+
+export default class App extends React.Component {
+  render() {
+    return (
+      <Router>
+        <div>
+          <AppBar />
+          <main>
+            <Route component={Navigation} />
+
+            <Route exact path="/(sent)?" component={SentTransactions} />
+            <Route exact path="/received" component={ReceivedTransactions} />
+            <Route path="/received/:id" component={ReceivedTransactionDetails} />
+          </main>
+        </div>
+      </Router>
+    );
+  }
+}

--- a/gui/src/components/AppBar.js
+++ b/gui/src/components/AppBar.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default class AppBar extends React.Component {
+  render() {
+    return <div>
+      <div className="mui-appbar">
+        <div className="inner">
+          <div className="mui--text-headline">Bridge Server</div>
+        </div>
+      </div>
+    </div>
+  }
+}

--- a/gui/src/components/Navigation.js
+++ b/gui/src/components/Navigation.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import Tabs from 'muicss/lib/react/tabs';
+import Tab from 'muicss/lib/react/tab';
+
+export default class Navigation extends React.Component {
+  constructor({history, location}) {
+    super();
+    this.state = {};
+    this.history = history;
+    this.state.selected = this.getActive(location.pathname);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const locationChanged = nextProps.location !== this.props.location;
+
+    if (locationChanged) {
+      let selected = this.getActive(nextProps.location.pathname);
+      this.setState({selected});
+    }
+  }
+
+  onChange(i, id) {
+    this.history.push("/"+id);
+  }
+
+  getActive(pathname) {
+    let state = {};
+    if (pathname.indexOf('/sent') == 0) {
+      return 0;
+    } else if (pathname.indexOf('/received') == 0) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  render() {
+    return <Tabs onChange={this.onChange.bind(this)} defaultSelectedIndex={this.state.selected}>
+      <Tab value="sent" label="Sent Transactions"></Tab>
+      <Tab value="received" label="Received Transactions"></Tab>
+    </Tabs>
+  }
+}

--- a/gui/src/components/ReceivedTransactionDetails.js
+++ b/gui/src/components/ReceivedTransactionDetails.js
@@ -1,0 +1,167 @@
+import React from 'react';
+import Panel from 'muicss/lib/react/panel';
+import axios from 'axios';
+import moment from 'moment';
+import querystring from 'querystring';
+
+export default class ReceivedTransactionDetails extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.id = props.match.params.id;
+    this.history = props.history;
+    axios.get('/admin/received-payments/'+this.id)
+      .then(response => this.setState({response: response.data}))
+      .catch(error => this.setState({error: true}));
+  }
+
+  asset(asset_type, asset_code, asset_issuer) {
+    let asset;
+    if (asset_type == 'native') {
+      return "XLM";
+    } else {
+      return <span>
+        {asset_code} (<code>{asset_issuer}</code>)
+      </span>
+    }
+  }
+
+  amount(operation) {
+    return <span>{operation.amount} {this.asset(operation.asset_type, operation.asset_code, operation.asset_issuer)}</span>;
+  }
+
+  back() {
+    if (this.history.length == 1) {
+      this.history.push("/received");
+    } else {
+      this.history.goBack();
+    }
+  }
+
+  reprocess() {
+    let force = false;
+    if (!window.confirm("Are you sure you want to reprocess this transaction?")) { 
+      return;
+    }
+
+    if (this.state.response.payment.status == "Success") {
+      if (!window.confirm("The payment was successfully processed before, do you want to continue?")) { 
+        return;
+      }
+      force = true;
+    }
+
+    this.setState({reprocessing: true});
+
+    axios.post('/reprocess/', querystring.stringify({operation_id: this.state.response.operation.id, force}))
+      .then(response => location.reload())
+      .catch(error => {
+        alert("Error sending reprocess request");
+        this.setState({reprocessing: false});
+      });
+  }
+
+  render() {
+    let processedAt;
+    if (this.state.response) {
+      processedAt = moment(this.state.response.payment.processed_at);
+    }
+
+    return <Panel>
+      {this.state.error ?
+        <div className="mui--text-center">Error loading payment...</div>
+      :
+      !this.state.response ?
+        <div className="mui--text-center">Loading...</div>
+      :
+        <div>
+          <div className="mui--pull-left">
+            <button className="mui-btn mui-btn--flat mui-btn--primary" onClick={this.back.bind(this)}>&laquo; back</button>
+          </div>
+          <div className="mui--pull-right">
+            <button className="mui-btn mui-btn--flat mui-btn--danger" onClick={this.reprocess.bind(this)} disabled={this.state.reprocessing}>
+            {!this.state.reprocessing ? "Reprocess" : "Reprocessing..."}
+          </button>
+          </div>
+          <div className="mui--clearfix"></div>
+
+          <div className="mui--text-headline">General</div>
+          <table className="mui-table details">
+            <tbody>
+              <tr>
+                <td>ID</td>
+                <td>{this.state.response.payment.id}</td>
+              </tr>
+              <tr>
+                <td>Status</td>
+                <td>{this.state.response.payment.status}</td>
+              </tr>
+              <tr>
+                <td>Processed At</td>
+                <td>{processedAt.format()+" ("+processedAt.fromNow()+")"}</td>
+              </tr>
+            </tbody>
+          </table>
+          <div className="mui--text-headline">Operation Details</div>
+          <table className="mui-table details">
+            <tbody>
+              <tr>
+                <td>Operation ID</td>
+                <td><a href={"https://horizon.stellar.org/operations/"+this.state.response.operation.id} target="_blank">{this.state.response.operation.id}</a></td>
+              </tr>
+              <tr>
+                <td>Type</td>
+                <td>{this.state.response.operation.type}</td>
+              </tr>
+              <tr>
+                <td>From</td>
+                <td><code>{this.state.response.operation.from}</code></td>
+              </tr>
+              <tr>
+                <td>To</td>
+                <td><code>{this.state.response.operation.to}</code></td>
+              </tr>
+              <tr>
+                <td>Amount</td>
+                <td>{this.amount(this.state.response.operation)}</td>
+              </tr>
+              <tr>
+                <td>Memo</td>
+                <td>{this.state.response.operation.memo.memo_type == 'none' ? <i>None</i> : <code>{this.state.response.operation.memo.memo}</code>}</td>
+              </tr>
+            </tbody>
+          </table>
+          <div className="mui--text-headline">Compliance Data</div>
+          {this.state.response.auth_data ?
+            <table className="mui-table details">
+              <tbody>
+                <tr>
+                  <td>Sender</td>
+                  <td>{this.state.response.auth_data.sender}</td>
+                </tr>
+                <tr>
+                  <td>Need Info</td>
+                  <td>{this.state.response.auth_data.need_info ? "true" : "false"}</td>
+                </tr>
+                <tr>
+                  <td>Tx</td>
+                  <td>
+                    <code style={{wordBreak: "break-all"}}>{this.state.response.auth_data.tx}</code>
+                    <br />
+                    <i className="material-icons">zoom_in</i> <a href={"https://www.stellar.org/laboratory/#xdr-viewer?input="+encodeURIComponent(this.state.response.auth_data.tx)+"&type=Transaction"} target="_blank">Inspect</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Attachment</td>
+                  <td><pre>{JSON.stringify(JSON.parse(this.state.response.auth_data.attachment), null, 2)}</pre></td>
+                </tr>
+              </tbody>
+            </table>
+            :
+            <div>No data...</div>
+          }
+        </div>
+      }
+      </Panel>
+  }
+}

--- a/gui/src/components/ReceivedTransactions.js
+++ b/gui/src/components/ReceivedTransactions.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import Panel from 'muicss/lib/react/panel';
+import axios from 'axios';
+import {Link} from 'react-router-dom';
+import moment from 'moment';
+import querystring from 'querystring';
+import defaults from 'lodash/defaults';
+
+export default class ReceivedTransactions extends React.Component {
+  constructor(props) {
+    super(props);
+    let query = this.parseQuery(props.location);
+    this.state = {loading: true, query, payments: []};
+    this.loadPage(query.page);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let query = this.parseQuery(nextProps.location);
+
+    if (this.state.query && this.state.query.page == query.page) {
+      return;
+    }
+
+    this.setState({loading: true, query});
+    this.loadPage(query.page);
+  }
+
+  parseQuery(location) {
+    let search = location.search.substr(1);
+    let query = querystring.parse(search);
+    return defaults(query, {page: 1});
+  }
+
+  loadPage(page) {
+    axios.get(`/admin/received-payments?page=${page}`)
+      .then(response => {
+        let loading = false;
+        let payments = response.data;
+        this.setState({loading, payments});
+      })
+      .catch(error => this.setState({error: true}));
+  }
+
+  render() {
+    return <Panel>
+        {this.state.error ?
+          <div className="mui--text-center">Error loading payments...</div>
+        :
+        this.state.loading ?
+          <div className="mui--text-center">Loading...</div>
+        :
+        <div>
+          <table className="mui-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Operation ID</th>
+                <th>Status</th>
+                <th>Processed At <i className="material-icons">arrow_drop_down</i></th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+            {
+              this.state.payments.length == 0 ?
+                <tr><td colSpan="5" className="mui--text-center">
+                  {this.state.query.page == 1 ? "No transactions found..." : "No more transactions found..."}
+                </td></tr>
+              :
+              this.state.payments.map(op => {
+                let processedAt = moment(op.processed_at);
+                return <tr key={op.id}>
+                  <td>{op.id}</td>
+                  <td><a href={"https://horizon.stellar.org/operations/"+op.operation_id} target="_blank">{op.operation_id}</a></td>
+                  <td>{op.status}</td>
+                  <td>{processedAt.format()+" ("+processedAt.fromNow()+")"}</td>
+                  <td><Link to={"/received/"+op.id}>Details</Link></td>
+                </tr>
+              })
+            }
+            </tbody>
+          </table>
+          {
+            this.state.query.page > 1
+            ?
+            <div className="mui--pull-left">
+              <Link to={{pathname: "/received", search: `?page=${parseInt(this.state.query.page)-1}`}}>
+              <button className="mui-btn mui-btn--flat mui-btn--primary">&laquo; previous page</button>
+              </Link>
+            </div>
+            :
+            null
+          }
+          {
+            this.state.payments.length == 10
+            ?
+            <div className="mui--pull-right">
+              <Link to={{pathname: "/received", search: `?page=${parseInt(this.state.query.page)+1}`}}>
+              <button className="mui-btn mui-btn--flat mui-btn--primary">next page &raquo;</button>
+              </Link>
+            </div>
+            :
+            null
+          }
+          <div className="mui--clearfix"></div>
+        </div>
+        }
+      </Panel>
+  }
+}

--- a/gui/src/components/SentTransactions.js
+++ b/gui/src/components/SentTransactions.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import Panel from 'muicss/lib/react/panel';
+import axios from 'axios';
+import {Link} from 'react-router-dom';
+import moment from 'moment';
+import querystring from 'querystring';
+import defaults from 'lodash/defaults';
+
+export default class SentTransactions extends React.Component {
+  constructor(props) {
+    super(props);
+    let query = this.parseQuery(props.location);
+    this.state = {loading: true, query, payments: []};
+    this.loadPage(query.page);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let query = this.parseQuery(nextProps.location);
+
+    if (this.state.query && this.state.query.page == query.page) {
+      return;
+    }
+
+    this.setState({loading: true, query});
+    this.loadPage(query.page);
+  }
+
+  parseQuery(location) {
+    let search = location.search.substr(1);
+    let query = querystring.parse(search);
+    return defaults(query, {page: 1});
+  }
+
+  loadPage(page) {
+    axios.get(`/admin/sent-transactions?page=${page}`)
+      .then(response => {
+        let loading = false;
+        let payments = response.data;
+        this.setState({loading, payments});
+      })
+      .catch(error => this.setState({error: true}));
+  }
+
+  render() {
+    return <Panel>
+        {this.state.error ?
+          <div className="mui--text-center">Error loading transactions...</div>
+        :
+        this.state.loading ?
+          <div className="mui--text-center">Loading...</div>
+        :
+        <div>
+          <table className="mui-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Transaction ID</th>
+                <th>Status</th>
+                <th>Processed At <i className="material-icons">arrow_drop_down</i></th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+            {
+              this.state.payments.length == 0 ?
+                <tr><td colSpan="5" className="mui--text-center">
+                  {this.state.query.page == 1 ? "No transactions found..." : "No more transactions found..."}
+                </td></tr>
+              :
+              this.state.payments.map(tx => {
+                let submittedAt = moment(tx.submitted_at);
+                return <tr key={tx.id}>
+                  <td>{tx.id}</td>
+                  <td><a href={"https://horizon.stellar.org/txerations/"+tx.transaction_id} target="_blank">{tx.transaction_id}</a></td>
+                  <td>{tx.status}</td>
+                  <td>{submittedAt.format()+" ("+submittedAt.fromNow()+")"}</td>
+                  <td>
+                    <i className="material-icons">zoom_in</i> <a href={"https://www.stellar.org/laboratory/#xdr-viewer?input="+encodeURIComponent(tx.envelope_xdr)+"&type=TransactionEnvelope"} target="_blank">Inspect</a>
+                  </td>
+                </tr>
+              })
+            }
+            </tbody>
+          </table>
+          {
+            this.state.query.page > 1
+            ?
+            <div className="mui--pull-left">
+              <Link to={{pathname: "/sent", search: `?page=${parseInt(this.state.query.page)-1}`}}>
+              <button className="mui-btn mui-btn--flat mui-btn--primary">&laquo; previous page</button>
+              </Link>
+            </div>
+            :
+            null
+          }
+          {
+            this.state.payments.length == 10
+            ?
+            <div className="mui--pull-right">
+              <Link to={{pathname: "/sent", search: `?page=${parseInt(this.state.query.page)+1}`}}>
+              <button className="mui-btn mui-btn--flat mui-btn--primary">next page &raquo;</button>
+              </Link>
+            </div>
+            :
+            null
+          }
+          <div className="mui--clearfix"></div>
+        </div>
+        }
+      </Panel>
+  }
+}

--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Bridge Server</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="apple-touch-icon" sizes="144x144" href="https://www.stellar.org/developers/images/favicon/rocket-144x144.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="https://www.stellar.org/developers/images/favicon/rocket-152x152.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.stellar.org/developers/images/favicon/rocket-180x180.png">
+  <link rel="icon" type="image/png" href="https://www.stellar.org/developers/images/favicon/rocket-96x96.png" sizes="96x96">
+  <meta name="msapplication-TileImage" content="https://www.stellar.org/developers/images/favicon/rocket-144x144.png">
+  <!-- load custom font -->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css" />
+  <!-- load MUI -->
+  <link href="https://cdn.muicss.com/mui-0.9.24/css/mui.min.css" rel="stylesheet" type="text/css" media="screen" />
+  <style type="text/css">
+    body {
+      background-color: #eeeeee;
+      font-family: "Roboto", "Helvetica Neue", Helvetica, Arial;
+    }
+
+    .mui-appbar .inner {
+      margin: 0 auto;
+      padding-top: 15px;
+      width: 90%;
+    }
+
+    main {
+      margin: 10px auto;
+      width: 90%;
+    }
+
+    .mui-tabs__bar {
+      margin-bottom: 10px;
+    }
+
+    .mui-tabs__bar>li>a {
+      cursor: pointer;
+    }
+
+    .mui-table.details td:first-child {
+      width: 200px;
+      font-weight: 500;
+      vertical-align: top;
+    }
+
+    i.material-icons {
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+
+<div id="app"></div>
+
+<script type="text/javascript" src="vendor.js"></script>
+<script type="text/javascript" src="app.js"></script>
+
+</body>
+</html>

--- a/src/github.com/stellar/gateway/bridge/config/config.go
+++ b/src/github.com/stellar/gateway/bridge/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	MACKey            string `mapstructure:"mac_key"`
 	APIKey            string `mapstructure:"api_key"`
 	NetworkPassphrase string `mapstructure:"network_passphrase"`
+	Develop           bool
 	Assets            []Asset
 	Database          struct {
 		Type string

--- a/src/github.com/stellar/gateway/bridge/gui/doc.go
+++ b/src/github.com/stellar/gateway/bridge/gui/doc.go
@@ -1,0 +1,4 @@
+// Package gui contains templates and static files used in bridge admin GUI.
+package gui
+
+//go:generate go-bindata -ignore .+\.go$ -pkg gui -o bindata.go -prefix ../../../../../../gui/dist ../../../../../../gui/dist

--- a/src/github.com/stellar/gateway/bridge/handlers/main.go
+++ b/src/github.com/stellar/gateway/bridge/handlers/main.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/stellar/gateway/bridge/config"
+	"github.com/stellar/gateway/db"
 	"github.com/stellar/gateway/external"
 	"github.com/stellar/gateway/horizon"
 	"github.com/stellar/gateway/listener"
@@ -14,6 +15,8 @@ type RequestHandler struct {
 	Config               *config.Config                          `inject:""`
 	Client               net.HTTPClientInterface                 `inject:""`
 	Horizon              horizon.HorizonInterface                `inject:""`
+	Driver               db.Driver                               `inject:""`
+	Repository           db.RepositoryInterface                  `inject:""`
 	StellarTomlResolver  external.StellarTomlClientInterface     `inject:""`
 	FederationResolver   external.FederationClientInterface      `inject:""`
 	TransactionSubmitter submitter.TransactionSubmitterInterface `inject:""`

--- a/src/github.com/stellar/gateway/bridge/handlers/request_handler_admin.go
+++ b/src/github.com/stellar/gateway/bridge/handlers/request_handler_admin.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stellar/gateway/db/entities"
+	"github.com/stellar/gateway/horizon"
+	"github.com/stellar/gateway/protocols"
+	callback "github.com/stellar/gateway/protocols/compliance"
+	"github.com/stellar/gateway/server"
+	"github.com/stellar/go/protocols/compliance"
+	"github.com/stellar/go/support/errors"
+	"github.com/zenazn/goji/web"
+)
+
+// AdminReceivedPayment implements /admin/received-payments/{id} endpoint
+func (rh *RequestHandler) AdminReceivedPayment(c web.C, w http.ResponseWriter, r *http.Request) {
+	object, err := rh.Driver.GetOne(&entities.ReceivedPayment{}, "id = ?", c.URLParams["id"])
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error getting ReceivedPayments")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
+	if object == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	payment := object.(*entities.ReceivedPayment)
+
+	paymentResponse, err := rh.Horizon.LoadOperation(payment.OperationID)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error getting operation from Horizon")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
+	err = rh.Horizon.LoadMemo(&paymentResponse)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error loading memo")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
+	var authData *compliance.AuthData
+	if paymentResponse.Memo.Type == "hash" && rh.Config.Compliance != "" {
+		authData, err = rh.getComplianceData(paymentResponse.Memo.Value)
+		if err != nil {
+			log.WithFields(log.Fields{"err": err}).Error("Error loading compliance data")
+			server.Write(w, protocols.InternalServerError)
+			return
+		}
+	}
+
+	response := struct {
+		Payment   *entities.ReceivedPayment `json:"payment"`
+		Operation horizon.PaymentResponse   `json:"operation"`
+		AuthData  *compliance.AuthData      `json:"auth_data"`
+	}{payment, paymentResponse, authData}
+
+	encoder := json.NewEncoder(w)
+	err = encoder.Encode(response)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err, "payments": payment}).Error("Error encoding ReceivedPayment")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+}
+
+func (rh *RequestHandler) getComplianceData(memo string) (*compliance.AuthData, error) {
+	complianceRequestURL := rh.Config.Compliance + "/receive"
+	complianceRequestBody := url.Values{"memo": {string(memo)}}
+
+	log.WithFields(log.Fields{"url": complianceRequestURL, "body": complianceRequestBody}).Info("Sending request to compliance server")
+	resp, err := rh.Client.PostForm(complianceRequestURL, complianceRequestBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error sending request to compliance server")
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error reading compliance server response")
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.WithFields(log.Fields{"status": resp.StatusCode, "body": string(body)}).Error("Error response from compliance server")
+		return nil, errors.New("Error response from compliance server")
+	}
+
+	var receiveResponse callback.ReceiveResponse
+	err = json.Unmarshal([]byte(body), &receiveResponse)
+	if err != nil {
+		return nil, errors.Wrap(err, "Cannot unmarshal receiveResponse")
+	}
+
+	var authData compliance.AuthData
+	err = json.Unmarshal([]byte(receiveResponse.Data), &authData)
+	if err != nil {
+		return nil, errors.Wrap(err, "Cannot unmarshal authData")
+	}
+
+	return &authData, nil
+}
+
+// AdminReceivedPayments implements /admin/received-payments endpoint
+func (rh *RequestHandler) AdminReceivedPayments(w http.ResponseWriter, r *http.Request) {
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	limit := 10
+
+	payments, err := rh.Repository.GetReceivedPayments(page, limit)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error loading ReceivedPayments")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
+	encoder := json.NewEncoder(w)
+	err = encoder.Encode(payments)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err, "payments": payments}).Error("Error encoding ReceivedPayments")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+}
+
+// AdminReceivedPayments implements /admin/sent-transactions endpoint
+func (rh *RequestHandler) AdminSentTransactions(w http.ResponseWriter, r *http.Request) {
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	limit := 10
+
+	transactions, err := rh.Repository.GetSentTransactions(page, limit)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Error loading SentTransactions")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+
+	encoder := json.NewEncoder(w)
+	err = encoder.Encode(transactions)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err, "transactions": transactions}).Error("Error encoding SentTransactions")
+		server.Write(w, protocols.InternalServerError)
+		return
+	}
+}

--- a/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder_test.go
+++ b/src/github.com/stellar/gateway/bridge/handlers/request_handler_builder_test.go
@@ -1,15 +1,11 @@
 package handlers
 
 import (
-	// "encoding/hex"
-	// "errors"
 	"net/http"
 	"net/http/httptest"
-	// "net/url"
 	"strings"
 	"testing"
 
-	"github.com/facebookgo/inject"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stellar/gateway/bridge/config"
 	"github.com/stellar/gateway/horizon"
@@ -21,31 +17,20 @@ import (
 
 func TestRequestHandlerBuilder(t *testing.T) {
 	c := &config.Config{NetworkPassphrase: "Test SDF Network ; September 2015"}
+
 	mockHorizon := new(mocks.MockHorizon)
 	mockHTTPClient := new(mocks.MockHTTPClient)
 	mockTransactionSubmitter := new(mocks.MockTransactionSubmitter)
 	mockFederationResolver := new(mocks.MockFederationResolver)
 	mockStellartomlResolver := new(mocks.MockStellartomlResolver)
-	requestHandler := RequestHandler{}
 
-	// Inject mocks
-	var g inject.Graph
-
-	err := g.Provide(
-		&inject.Object{Value: &requestHandler},
-		&inject.Object{Value: c},
-		&inject.Object{Value: mockHorizon},
-		&inject.Object{Value: mockHTTPClient},
-		&inject.Object{Value: mockTransactionSubmitter},
-		&inject.Object{Value: mockFederationResolver},
-		&inject.Object{Value: mockStellartomlResolver},
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	if err := g.Populate(); err != nil {
-		panic(err)
+	requestHandler := RequestHandler{
+		Config:               c,
+		Client:               mockHTTPClient,
+		Horizon:              mockHorizon,
+		TransactionSubmitter: mockTransactionSubmitter,
+		FederationResolver:   mockFederationResolver,
+		StellarTomlResolver:  mockStellartomlResolver,
 	}
 
 	testServer := httptest.NewServer(http.HandlerFunc(requestHandler.Builder))

--- a/src/github.com/stellar/gateway/bridge/handlers/request_handler_payment_test.go
+++ b/src/github.com/stellar/gateway/bridge/handlers/request_handler_payment_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/facebookgo/inject"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stellar/gateway/bridge/config"
 	"github.com/stellar/gateway/horizon"
@@ -37,26 +36,14 @@ func TestRequestHandlerPayment(t *testing.T) {
 	mockTransactionSubmitter := new(mocks.MockTransactionSubmitter)
 	mockFederationResolver := new(mocks.MockFederationResolver)
 	mockStellartomlResolver := new(mocks.MockStellartomlResolver)
-	requestHandler := RequestHandler{}
 
-	// Inject mocks
-	var g inject.Graph
-
-	err := g.Provide(
-		&inject.Object{Value: &requestHandler},
-		&inject.Object{Value: c},
-		&inject.Object{Value: mockHorizon},
-		&inject.Object{Value: mockHTTPClient},
-		&inject.Object{Value: mockTransactionSubmitter},
-		&inject.Object{Value: mockFederationResolver},
-		&inject.Object{Value: mockStellartomlResolver},
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	if err := g.Populate(); err != nil {
-		panic(err)
+	requestHandler := RequestHandler{
+		Config:               c,
+		Client:               mockHTTPClient,
+		Horizon:              mockHorizon,
+		TransactionSubmitter: mockTransactionSubmitter,
+		FederationResolver:   mockFederationResolver,
+		StellarTomlResolver:  mockStellartomlResolver,
 	}
 
 	testServer := httptest.NewServer(http.HandlerFunc(requestHandler.Payment))

--- a/src/github.com/stellar/gateway/db/driver.go
+++ b/src/github.com/stellar/gateway/db/driver.go
@@ -16,5 +16,5 @@ type Driver interface {
 	Delete(object entities.Entity) (err error)
 
 	GetOne(object entities.Entity, where string, params ...interface{}) (entities.Entity, error)
-	GetMany(slice interface{}, where, order, limit *string, params ...interface{}) (err error)
+	GetMany(slice interface{}, where, order, offset, limit *string, params ...interface{}) (err error)
 }

--- a/src/github.com/stellar/gateway/db/driver.go
+++ b/src/github.com/stellar/gateway/db/driver.go
@@ -16,4 +16,5 @@ type Driver interface {
 	Delete(object entities.Entity) (err error)
 
 	GetOne(object entities.Entity, where string, params ...interface{}) (entities.Entity, error)
+	GetMany(slice interface{}, where, order, limit *string, params ...interface{}) (err error)
 }

--- a/src/github.com/stellar/gateway/db/drivers/mysql/bindata.go
+++ b/src/github.com/stellar/gateway/db/drivers/mysql/bindata.go
@@ -84,7 +84,7 @@ func migrations_gateway01_initSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations_gateway/01_init.sql", size: 847, mode: os.FileMode(420), modTime: time.Unix(1472146842, 0)}
+	info := bindataFileInfo{name: "migrations_gateway/01_init.sql", size: 847, mode: os.FileMode(420), modTime: time.Unix(1461004393, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func migrations_compliance01_initSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations_compliance/01_init.sql", size: 1133, mode: os.FileMode(420), modTime: time.Unix(1472146842, 0)}
+	info := bindataFileInfo{name: "migrations_compliance/01_init.sql", size: 1133, mode: os.FileMode(420), modTime: time.Unix(1461004393, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"migrations_gateway/01_init.sql":    migrations_gateway01_initSql,
+	"migrations_gateway/01_init.sql": migrations_gateway01_initSql,
 	"migrations_compliance/01_init.sql": migrations_compliance01_initSql,
 }
 
@@ -204,7 +204,6 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"migrations_compliance": &bintree{nil, map[string]*bintree{
 		"01_init.sql": &bintree{migrations_compliance01_initSql, map[string]*bintree{}},
@@ -260,3 +259,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/src/github.com/stellar/gateway/db/drivers/mysql/main.go
+++ b/src/github.com/stellar/gateway/db/drivers/mysql/main.go
@@ -170,7 +170,7 @@ func (d *Driver) GetOne(object entities.Entity, where string, params ...interfac
 }
 
 // GetMany returns many entities
-func (d *Driver) GetMany(slice interface{}, where, order, limit *string, params ...interface{}) (err error) {
+func (d *Driver) GetMany(slice interface{}, where, order, offset, limit *string, params ...interface{}) (err error) {
 	_, tableName, err := getTypeData(slice)
 	if err != nil {
 		return
@@ -188,7 +188,9 @@ func (d *Driver) GetMany(slice interface{}, where, order, limit *string, params 
 		query.WriteString(" ORDER BY " + *order)
 	}
 
-	if limit != nil {
+	if limit != nil && offset != nil {
+		query.WriteString(fmt.Sprintf(" LIMIT %s, %s", *offset, *limit))
+	} else if limit != nil {
 		query.WriteString(" LIMIT " + *limit)
 	}
 

--- a/src/github.com/stellar/gateway/db/drivers/mysql/main.go
+++ b/src/github.com/stellar/gateway/db/drivers/mysql/main.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"reflect"
@@ -168,6 +169,55 @@ func (d *Driver) GetOne(object entities.Entity, where string, params ...interfac
 	return object, err
 }
 
+// GetMany returns many entities
+func (d *Driver) GetMany(slice interface{}, where, order, limit *string, params ...interface{}) (err error) {
+	_, tableName, err := getTypeData(slice)
+	if err != nil {
+		return
+	}
+
+	var query bytes.Buffer
+
+	query.WriteString("SELECT * FROM " + tableName)
+
+	if where != nil {
+		query.WriteString(" WHERE " + *where)
+	}
+
+	if order != nil {
+		query.WriteString(" ORDER BY " + *order)
+	}
+
+	if limit != nil {
+		query.WriteString(" LIMIT " + *limit)
+	}
+
+	query.WriteString(";")
+
+	switch slice := slice.(type) {
+	case *[]*entities.ReceivedPayment:
+		err = d.database.Select(slice, query.String(), params...)
+		tmp := *slice
+		for i := range tmp {
+			tmp[i].SetExists()
+		}
+		slice = &tmp
+	case *[]*entities.SentTransaction:
+		err = d.database.Select(slice, query.String(), params...)
+		tmp := *slice
+		for i := range tmp {
+			tmp[i].SetExists()
+		}
+		slice = &tmp
+	}
+
+	if err != nil && err.Error() == "sql: no rows in result set" {
+		return nil
+	}
+
+	return
+}
+
 func getTypeData(object interface{}) (typeValue reflect.Type, tableName string, err error) {
 	switch object := object.(type) {
 	case *entities.AuthorizedTransaction:
@@ -184,6 +234,10 @@ func getTypeData(object interface{}) (typeValue reflect.Type, tableName string, 
 		tableName = "SentTransaction"
 	case *entities.ReceivedPayment:
 		typeValue = reflect.TypeOf(*object)
+		tableName = "ReceivedPayment"
+	case *[]*entities.SentTransaction:
+		tableName = "SentTransaction"
+	case *[]*entities.ReceivedPayment:
 		tableName = "ReceivedPayment"
 	default:
 		return typeValue, tableName, fmt.Errorf("Unknown entity type: %T", object)

--- a/src/github.com/stellar/gateway/db/drivers/postgres/bindata.go
+++ b/src/github.com/stellar/gateway/db/drivers/postgres/bindata.go
@@ -84,7 +84,7 @@ func migrations_gateway01_initSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations_gateway/01_init.sql", size: 651, mode: os.FileMode(420), modTime: time.Unix(1473881382, 0)}
+	info := bindataFileInfo{name: "migrations_gateway/01_init.sql", size: 651, mode: os.FileMode(420), modTime: time.Unix(1476130062, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func migrations_compliance01_initSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations_compliance/01_init.sql", size: 992, mode: os.FileMode(420), modTime: time.Unix(1475617538, 0)}
+	info := bindataFileInfo{name: "migrations_compliance/01_init.sql", size: 992, mode: os.FileMode(420), modTime: time.Unix(1476985200, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"migrations_gateway/01_init.sql":    migrations_gateway01_initSql,
+	"migrations_gateway/01_init.sql": migrations_gateway01_initSql,
 	"migrations_compliance/01_init.sql": migrations_compliance01_initSql,
 }
 
@@ -204,7 +204,6 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"migrations_compliance": &bintree{nil, map[string]*bintree{
 		"01_init.sql": &bintree{migrations_compliance01_initSql, map[string]*bintree{}},
@@ -260,3 +259,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/src/github.com/stellar/gateway/db/drivers/postgres/main.go
+++ b/src/github.com/stellar/gateway/db/drivers/postgres/main.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"reflect"
 	"strings"
 
@@ -168,8 +167,9 @@ func (d *Driver) GetOne(object entities.Entity, where string, params ...interfac
 		return nil, err
 	}
 
-	sql := "SELECT * FROM " + tableName + " WHERE " + where + " LIMIT 1"
-	log.Println(sql)
+	sql := "SELECT * FROM " + tableName + " WHERE " + where + " LIMIT 1;"
+	sql = sqlx.Rebind(sqlx.DOLLAR, sql)
+
 	err = d.database.Get(object, sql, params...)
 	if err != nil {
 		if err.Error() == "sql: no rows in result set" {
@@ -182,7 +182,7 @@ func (d *Driver) GetOne(object entities.Entity, where string, params ...interfac
 }
 
 // GetMany returns many entities
-func (d *Driver) GetMany(slice interface{}, where, order, limit *string, params ...interface{}) (err error) {
+func (d *Driver) GetMany(slice interface{}, where, order, offset, limit *string, params ...interface{}) (err error) {
 	_, tableName, err := getTypeData(slice)
 	if err != nil {
 		return
@@ -198,6 +198,10 @@ func (d *Driver) GetMany(slice interface{}, where, order, limit *string, params 
 
 	if order != nil {
 		query.WriteString(" ORDER BY " + *order)
+	}
+
+	if offset != nil {
+		query.WriteString(" OFFSET " + *offset)
 	}
 
 	if limit != nil {

--- a/src/github.com/stellar/gateway/db/entities/received_payment.go
+++ b/src/github.com/stellar/gateway/db/entities/received_payment.go
@@ -7,11 +7,11 @@ import (
 // ReceivedPayment represents payment received by the gateway server
 type ReceivedPayment struct {
 	exists      bool
-	ID          *int64    `db:"id"`
-	OperationID string    `db:"operation_id"`
-	ProcessedAt time.Time `db:"processed_at"`
-	PagingToken string    `db:"paging_token"`
-	Status      string    `db:"status"`
+	ID          *int64    `db:"id" json:"id"`
+	OperationID string    `db:"operation_id" json:"operation_id"`
+	ProcessedAt time.Time `db:"processed_at" json:"processed_at"`
+	PagingToken string    `db:"paging_token" json:"paging_token"`
+	Status      string    `db:"status" json:"status"`
 }
 
 // GetID returns ID of the entity

--- a/src/github.com/stellar/gateway/db/entities/sent_transaction.go
+++ b/src/github.com/stellar/gateway/db/entities/sent_transaction.go
@@ -2,11 +2,22 @@ package entities
 
 import (
 	"database/sql/driver"
+	"errors"
 	"time"
 )
 
 // SentTransactionStatus type represents sent transaction status
 type SentTransactionStatus string
+
+// Scan implements database/sql.Scanner interface
+func (s *SentTransactionStatus) Scan(src interface{}) error {
+	value, ok := src.([]byte)
+	if !ok {
+		return errors.New("Cannot convert value to SentTransactionStatus")
+	}
+	*s = SentTransactionStatus(value)
+	return nil
+}
 
 // Value implements driver.Valuer
 func (status SentTransactionStatus) Value() (driver.Value, error) {
@@ -27,15 +38,15 @@ const (
 // SentTransaction represents transaction sent by the gateway server
 type SentTransaction struct {
 	exists        bool
-	ID            *int64                `db:"id"`
-	TransactionID string                `db:"transaction_id"`
-	Status        SentTransactionStatus `db:"status"` // sending/success/failure
-	Source        string                `db:"source"`
-	SubmittedAt   time.Time             `db:"submitted_at"`
-	SucceededAt   *time.Time            `db:"succeeded_at"`
-	Ledger        *uint64               `db:"ledger"`
-	EnvelopeXdr   string                `db:"envelope_xdr"`
-	ResultXdr     *string               `db:"result_xdr"`
+	ID            *int64                `db:"id" json:"id"`
+	TransactionID string                `db:"transaction_id" json:"transaction_id"`
+	Status        SentTransactionStatus `db:"status" json:"status"` // sending/success/failure
+	Source        string                `db:"source" json:"source"`
+	SubmittedAt   time.Time             `db:"submitted_at" json:"submitted_at"`
+	SucceededAt   *time.Time            `db:"succeeded_at" json:"succeeded_at"`
+	Ledger        *uint64               `db:"ledger" json:"ledger"`
+	EnvelopeXdr   string                `db:"envelope_xdr" json:"envelope_xdr"`
+	ResultXdr     *string               `db:"result_xdr" json:"result_xdr"`
 }
 
 // GetID returns ID of the entity

--- a/src/github.com/stellar/gateway/db/repository.go
+++ b/src/github.com/stellar/gateway/db/repository.go
@@ -151,9 +151,11 @@ func (r Repository) GetReceivedPayments(page, limit int) ([]*entities.ReceivedPa
 
 	offset := (page - 1) * limit
 
-	limitQuery := fmt.Sprintf("%d, %d", offset, limit)
+	limitQuery := fmt.Sprintf("%d", limit)
+	offsetQuery := fmt.Sprintf("%d", offset)
 	orderQuery := "id desc"
-	err := r.driver.GetMany(&payments, nil, &orderQuery, &limitQuery)
+
+	err := r.driver.GetMany(&payments, nil, &orderQuery, &offsetQuery, &limitQuery)
 	return payments, err
 }
 
@@ -167,9 +169,11 @@ func (r Repository) GetSentTransactions(page, limit int) ([]*entities.SentTransa
 
 	offset := (page - 1) * limit
 
-	limitQuery := fmt.Sprintf("%d, %d", offset, limit)
+	limitQuery := fmt.Sprintf("%d", limit)
+	offsetQuery := fmt.Sprintf("%d", offset)
 	orderQuery := "id desc"
-	err := r.driver.GetMany(&transactions, nil, &orderQuery, &limitQuery)
+
+	err := r.driver.GetMany(&transactions, nil, &orderQuery, &offsetQuery, &limitQuery)
 	return transactions, err
 }
 

--- a/src/github.com/stellar/gateway/horizon/payment_response.go
+++ b/src/github.com/stellar/gateway/horizon/payment_response.go
@@ -24,5 +24,5 @@ type PaymentResponse struct {
 	Memo struct {
 		Type  string `json:"memo_type"`
 		Value string `json:"memo"`
-	}
+	} `json:"memo"`
 }

--- a/src/github.com/stellar/gateway/mocks/main.go
+++ b/src/github.com/stellar/gateway/mocks/main.go
@@ -158,6 +158,22 @@ func (m *MockRepository) GetReceivedPaymentByOperationID(operationID int64) (*en
 	return a.Get(0).(*entities.ReceivedPayment), a.Error(1)
 }
 
+func (m *MockRepository) GetReceivedPayments(page, limit int) ([]*entities.ReceivedPayment, error) {
+	a := m.Called(page, limit)
+	if a.Get(0) == nil {
+		return nil, a.Error(1)
+	}
+	return a.Get(0).([]*entities.ReceivedPayment), a.Error(1)
+}
+
+func (m *MockRepository) GetSentTransactions(page, limit int) ([]*entities.SentTransaction, error) {
+	a := m.Called(page, limit)
+	if a.Get(0) == nil {
+		return nil, a.Error(1)
+	}
+	return a.Get(0).([]*entities.SentTransaction), a.Error(1)
+}
+
 // MockSignerVerifier ...
 type MockSignerVerifier struct {
 	mock.Mock

--- a/src/github.com/stellar/gateway/server/middlewares.go
+++ b/src/github.com/stellar/gateway/server/middlewares.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 )
 
 // StripTrailingSlashMiddleware strips trailing slash.
@@ -10,6 +11,13 @@ func StripTrailingSlashMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			path := r.URL.Path
+
+			// Do not change /admin paths
+			if strings.HasPrefix(path, "/admin") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			l := len(path)
 
 			// if the path is longer than 1 char (i.e., not '/')
@@ -28,6 +36,12 @@ func StripTrailingSlashMiddleware() func(next http.Handler) http.Handler {
 func HeadersMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
+			// Do not change admin home
+			if r.URL.Path == "/admin/" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			w.Header().Set("Content-Type", "application/json")
 			next.ServeHTTP(w, r)
 		}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -119,6 +119,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/elazarl/go-bindata-assetfs",
+			"repository": "https://github.com/elazarl/go-bindata-assetfs",
+			"revision": "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/facebookgo/inject",
 			"repository": "https://github.com/facebookgo/inject",
 			"revision": "d5029152fecb2a8e68f7f8eb3c6391fc8ee70496",

--- a/vendor/src/github.com/elazarl/go-bindata-assetfs/LICENSE
+++ b/vendor/src/github.com/elazarl/go-bindata-assetfs/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2014, Elazar Leibovich
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/src/github.com/elazarl/go-bindata-assetfs/README.md
+++ b/vendor/src/github.com/elazarl/go-bindata-assetfs/README.md
@@ -1,0 +1,46 @@
+# go-bindata-assetfs
+
+Serve embedded files from [jteeuwen/go-bindata](https://github.com/jteeuwen/go-bindata) with `net/http`.
+
+[GoDoc](http://godoc.org/github.com/elazarl/go-bindata-assetfs)
+
+### Installation
+
+Install with
+
+    $ go get github.com/jteeuwen/go-bindata/...
+    $ go get github.com/elazarl/go-bindata-assetfs/...
+
+### Creating embedded data
+
+Usage is identical to [jteeuwen/go-bindata](https://github.com/jteeuwen/go-bindata) usage,
+instead of running `go-bindata` run `go-bindata-assetfs`.
+
+The tool will create a `bindata_assetfs.go` file, which contains the embedded data.
+
+A typical use case is
+
+    $ go-bindata-assetfs data/...
+
+### Using assetFS in your code
+
+The generated file provides an `assetFS()` function that returns a `http.Filesystem`
+wrapping the embedded files. What you usually want to do is:
+
+    http.Handle("/", http.FileServer(assetFS()))
+
+This would run an HTTP server serving the embedded files.
+
+## Without running binary tool
+
+You can always just run the `go-bindata` tool, and then
+
+use
+
+     import "github.com/elazarl/go-bindata-assetfs"
+     ...
+     http.Handle("/",
+        http.FileServer(
+        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: AssetInfo, Prefix: "data"}))
+
+to serve files embedded from the `data` directory.

--- a/vendor/src/github.com/elazarl/go-bindata-assetfs/assetfs.go
+++ b/vendor/src/github.com/elazarl/go-bindata-assetfs/assetfs.go
@@ -1,0 +1,167 @@
+package assetfs
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var (
+	defaultFileTimestamp = time.Now()
+)
+
+// FakeFile implements os.FileInfo interface for a given path and size
+type FakeFile struct {
+	// Path is the path of this file
+	Path string
+	// Dir marks of the path is a directory
+	Dir bool
+	// Len is the length of the fake file, zero if it is a directory
+	Len int64
+	// Timestamp is the ModTime of this file
+	Timestamp time.Time
+}
+
+func (f *FakeFile) Name() string {
+	_, name := filepath.Split(f.Path)
+	return name
+}
+
+func (f *FakeFile) Mode() os.FileMode {
+	mode := os.FileMode(0644)
+	if f.Dir {
+		return mode | os.ModeDir
+	}
+	return mode
+}
+
+func (f *FakeFile) ModTime() time.Time {
+	return f.Timestamp
+}
+
+func (f *FakeFile) Size() int64 {
+	return f.Len
+}
+
+func (f *FakeFile) IsDir() bool {
+	return f.Mode().IsDir()
+}
+
+func (f *FakeFile) Sys() interface{} {
+	return nil
+}
+
+// AssetFile implements http.File interface for a no-directory file with content
+type AssetFile struct {
+	*bytes.Reader
+	io.Closer
+	FakeFile
+}
+
+func NewAssetFile(name string, content []byte, timestamp time.Time) *AssetFile {
+	if timestamp.IsZero() {
+		timestamp = defaultFileTimestamp
+	}
+	return &AssetFile{
+		bytes.NewReader(content),
+		ioutil.NopCloser(nil),
+		FakeFile{name, false, int64(len(content)), timestamp}}
+}
+
+func (f *AssetFile) Readdir(count int) ([]os.FileInfo, error) {
+	return nil, errors.New("not a directory")
+}
+
+func (f *AssetFile) Size() int64 {
+	return f.FakeFile.Size()
+}
+
+func (f *AssetFile) Stat() (os.FileInfo, error) {
+	return f, nil
+}
+
+// AssetDirectory implements http.File interface for a directory
+type AssetDirectory struct {
+	AssetFile
+	ChildrenRead int
+	Children     []os.FileInfo
+}
+
+func NewAssetDirectory(name string, children []string, fs *AssetFS) *AssetDirectory {
+	fileinfos := make([]os.FileInfo, 0, len(children))
+	for _, child := range children {
+		_, err := fs.AssetDir(filepath.Join(name, child))
+		fileinfos = append(fileinfos, &FakeFile{child, err == nil, 0, time.Time{}})
+	}
+	return &AssetDirectory{
+		AssetFile{
+			bytes.NewReader(nil),
+			ioutil.NopCloser(nil),
+			FakeFile{name, true, 0, time.Time{}},
+		},
+		0,
+		fileinfos}
+}
+
+func (f *AssetDirectory) Readdir(count int) ([]os.FileInfo, error) {
+	if count <= 0 {
+		return f.Children, nil
+	}
+	if f.ChildrenRead+count > len(f.Children) {
+		count = len(f.Children) - f.ChildrenRead
+	}
+	rv := f.Children[f.ChildrenRead : f.ChildrenRead+count]
+	f.ChildrenRead += count
+	return rv, nil
+}
+
+func (f *AssetDirectory) Stat() (os.FileInfo, error) {
+	return f, nil
+}
+
+// AssetFS implements http.FileSystem, allowing
+// embedded files to be served from net/http package.
+type AssetFS struct {
+	// Asset should return content of file in path if exists
+	Asset func(path string) ([]byte, error)
+	// AssetDir should return list of files in the path
+	AssetDir func(path string) ([]string, error)
+	// AssetInfo should return the info of file in path if exists
+	AssetInfo func(path string) (os.FileInfo, error)
+	// Prefix would be prepended to http requests
+	Prefix string
+}
+
+func (fs *AssetFS) Open(name string) (http.File, error) {
+	name = path.Join(fs.Prefix, name)
+	if len(name) > 0 && name[0] == '/' {
+		name = name[1:]
+	}
+	if b, err := fs.Asset(name); err == nil {
+		timestamp := defaultFileTimestamp
+		if fs.AssetInfo != nil {
+			if info, err := fs.AssetInfo(name); err == nil {
+				timestamp = info.ModTime()
+			}
+		}
+		return NewAssetFile(name, b, timestamp), nil
+	}
+	if children, err := fs.AssetDir(name); err == nil {
+		return NewAssetDirectory(name, children, fs), nil
+	} else {
+		// If the error is not found, return an error that will
+		// result in a 404 error. Otherwise the server returns
+		// a 500 error for files not found.
+		if strings.Contains(err.Error(), "not found") {
+			return nil, os.ErrNotExist
+		}
+		return nil, err
+	}
+}

--- a/vendor/src/github.com/elazarl/go-bindata-assetfs/doc.go
+++ b/vendor/src/github.com/elazarl/go-bindata-assetfs/doc.go
@@ -1,0 +1,13 @@
+// assetfs allows packages to serve static content embedded
+// with the go-bindata tool with the standard net/http package.
+//
+// See https://github.com/jteeuwen/go-bindata for more information
+// about embedding binary data with go-bindata.
+//
+// Usage example, after running
+//    $ go-bindata data/...
+// use:
+//     http.Handle("/",
+//        http.FileServer(
+//        &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "data"}))
+package assetfs

--- a/vendor/src/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs/main.go
+++ b/vendor/src/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const bindatafile = "bindata.go"
+
+func isDebug(args []string) bool {
+	flagset := flag.NewFlagSet("", flag.ContinueOnError)
+	debug := flagset.Bool("debug", false, "")
+	debugArgs := make([]string, 0)
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-debug") {
+			debugArgs = append(debugArgs, arg)
+		}
+	}
+	flagset.Parse(debugArgs)
+	if debug == nil {
+		return false
+	}
+	return *debug
+}
+
+func main() {
+	if _, err := exec.LookPath("go-bindata"); err != nil {
+		fmt.Println("Cannot find go-bindata executable in path")
+		fmt.Println("Maybe you need: go get github.com/elazarl/go-bindata-assetfs/...")
+		os.Exit(1)
+	}
+	cmd := exec.Command("go-bindata", os.Args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		os.Exit(1)
+	}
+	in, err := os.Open(bindatafile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot read", bindatafile, err)
+		return
+	}
+	out, err := os.Create("bindata_assetfs.go")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot write 'bindata_assetfs.go'", err)
+		return
+	}
+	debug := isDebug(os.Args[1:])
+	r := bufio.NewReader(in)
+	done := false
+	for line, isPrefix, err := r.ReadLine(); err == nil; line, isPrefix, err = r.ReadLine() {
+		if !isPrefix {
+			line = append(line, '\n')
+		}
+		if _, err := out.Write(line); err != nil {
+			fmt.Fprintln(os.Stderr, "Cannot write to 'bindata_assetfs.go'", err)
+			return
+		}
+		if !done && !isPrefix && bytes.HasPrefix(line, []byte("import (")) {
+			if debug {
+				fmt.Fprintln(out, "\t\"net/http\"")
+			} else {
+				fmt.Fprintln(out, "\t\"github.com/elazarl/go-bindata-assetfs\"")
+			}
+			done = true
+		}
+	}
+	if debug {
+		fmt.Fprintln(out, `
+func assetFS() http.FileSystem {
+	for k := range _bintree.Children {
+		return http.Dir(k)
+	}
+	panic("unreachable")
+}`)
+	} else {
+		fmt.Fprintln(out, `
+func assetFS() *assetfs.AssetFS {
+	assetInfo := func(path string) (os.FileInfo, error) {
+		return os.Stat(path)
+	}
+	for k := range _bintree.Children {
+		return &assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: assetInfo, Prefix: k}
+	}
+	panic("unreachable")
+}`)
+	}
+	// Close files BEFORE remove calls (don't use defer).
+	in.Close()
+	out.Close()
+	if err := os.Remove(bindatafile); err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot remove", bindatafile, err)
+	}
+}


### PR DESCRIPTION
This PR adds a simple Admin GUI. It's the MVP: some features like searching, filtering, sorting, CSV file export can be added in another PR.

TODO:
- [x] Test with postgres.
- [x] Static files compilation. Standard [`go-bindata`](https://github.com/jteeuwen/go-bindata) and static file server or something different? @nullstyle wanted to discuss this.
- [ ] `/admin/config` endpoint to expose helpful config values like `horizon`.

Nice haves:
- [ ] Create abstract `Page` component for pages (code duplication).
- [ ] Remove external js, css files.

### Sent Transactions
![bridge-sent](https://user-images.githubusercontent.com/464938/30218341-1c794250-94b9-11e7-8d03-40e67e06f66f.png)

### Received Transactions
![bridge-received](https://user-images.githubusercontent.com/464938/30218347-2171ffc2-94b9-11e7-96e5-c80a72e8b0fe.png)

### Received Transaction Details
![bridge-received-details](https://user-images.githubusercontent.com/464938/30218357-27064c90-94b9-11e7-9b49-ae198d35b251.png)
