### PR TITLE
Fix AllowedFI table name

### DIFF
--- a/src/github.com/stellar/gateway/db/drivers/mysql/main.go
+++ b/src/github.com/stellar/gateway/db/drivers/mysql/main.go
@@ -175,7 +175,7 @@ func getTypeData(object interface{}) (typeValue reflect.Type, tableName string, 
 		tableName = "AuthorizedTransaction"
 	case *entities.AllowedFi:
 		typeValue = reflect.TypeOf(*object)
-		tableName = "AllowedFi"
+		tableName = "AllowedFI"
 	case *entities.AllowedUser:
 		typeValue = reflect.TypeOf(*object)
 		tableName = "AllowedUser"

--- a/src/github.com/stellar/gateway/db/drivers/postgres/main.go
+++ b/src/github.com/stellar/gateway/db/drivers/postgres/main.go
@@ -187,7 +187,7 @@ func getTypeData(object interface{}) (typeValue reflect.Type, tableName string, 
 		tableName = "AuthorizedTransaction"
 	case *entities.AllowedFi:
 		typeValue = reflect.TypeOf(*object)
-		tableName = "AllowedFi"
+		tableName = "AllowedFI"
 	case *entities.AllowedUser:
 		typeValue = reflect.TypeOf(*object)
 		tableName = "AllowedUser"


### PR DESCRIPTION
Table names in MySQL run in Windows are case sensitive. Change all table
name occurences to match migration files.

Fix #72